### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,36 @@
+# Helps auto-assign code reviews for pull requests
+# The last match will 'win'
+
+# Global owners 
+*                               @lmz    @FlaviaTsang
+
+# DevOps / Quality Assurance
+/.github/                       @e-lo    @lmz
+setup.config                    @e-lo    @lmz
+pre-commit-config.yaml          @e-lo    @lmz
+.markdownlint.yaml              @e-lo    @lmz
+
+# Documentation Setup
+/docs/                         @e-lo    @lmz  
+mkdocs.yml                     @e-lo    @lmz
+
+# Documentation Content
+*.md                            @lmz     @FlaviaTsang
+
+# Tests should be reviewed by dev team
+pytest.ini                      @e-lo   @inrokevin  @lmz 
+/tests/                         @e-lo   @inrokevin  @lmz 
+
+# EMME related things should be reviewed by INRO
+/tm2py/emme/                    @inrokevin 
+
+# Packaging
+setup.py                         @e-lo          @lmz 
+*requirements*.txt               @inrokevin     @lmz    
+manifest.in                      @e-lo          @lmz 
+environment.yml                  @inrokevin     @lmz 
+Dockerfile                       @inrokevin     @lmz
+/bin/                            @inrokevin     @lmz         @e-lo
+
+# Examples
+/examples/                       @FlaviaTsang   @i-am-sijia


### PR DESCRIPTION
This pull request adds a CODEOWNERS file in order to automate assigning of reviewers.

#### Issues List

closes #62 

## TODO

@lmz please update with GH handles for who you would like to be flagged.  I took a wild guess at many of these and suspect you have many other ideas.


