### PR TITLE
Add .devcontainer capabilities

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# FROM: 
+# https://github.com/microsoft/vscode-dev-containers/blob/v0.177.0/containers/python-3/.devcontainer
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT=3.7
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// For format details, see https://aka.ms/devcontainer.json. 
+// For config options, see the README at:
+//     https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3
+{
+    "name": "Python 3",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+            // Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+            "VARIANT": "3.7",
+            // Options
+            "INSTALL_NODE": "false",
+            "NODE_VERSION": "lts/*"
+        }
+    },
+
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "python.pythonPath": "/usr/local/bin/python",
+        "python.languageServer": "Pylance",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true
+    },
+
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "davidanson.vscode-markdownlint",
+        "bierner.markdown-mermaid",
+        "mhutchie.git-graph"
+    ],
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode",
+    "portsAttributes": {
+        "8000": {
+            "label": "documentation website"
+        }
+    }
+}


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?
*As a developer, I'd like to work in a consistent development environment.*

This pull request works towards this capability by adding a .devcontainer and .vscode settings. 

## `.devcontainer`

- [.devcontainer ](https://code.visualstudio.com/docs/remote/containers) setup which defines a development container for VS Code

This can be leveraged when working in https://vscode.dev/ web-based IDE environment.  However, creating the capability to to development **completely** requires organizations to sign up for  [GitHub Codespaces](https://docs.github.com/en/codespaces/overview) in their enterprise subscription.  

Another potentially interesting option for MTC would be to configuring a local-server on a machine that has an Emme license. 

## `.vscode`

### `settings.json`
As of now there are not a lot of project-specific settings that I could think of, but included a small handful.

### `extensions`

Added a handful of useful ones as "recommended".


@lmz I leave it to you to decide if/when/how to integrate this PR - my guess is that it is most useful as you have staff working on this.

## Applicable Issues

Addresses #20
 