### PR TITLE
Add publish on release created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,11 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [created]
+  release
 
 jobs:
   
-  deploy:
+  build-publish:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We already have a publish workflow - this just modifies it slightly to publish on release.

Fixes #3 


NOTE: this functionality will fail/not work until #5 is resolved.