### PR TITLE
Prepare demand

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -476,6 +476,8 @@
     generic_highway_mode_code = "c"
     # include other MAZs to estimate density (pop+jobs*2.5)/acres for each MAZ
     area_type_buffer_dist_miles = 0.5
+    # nodes at interchanges
+    interchange_nodes_file = "inputs/hwy/interchange_nodes.csv"
     [highway.tolls]
         file_path = "inputs/hwy/tolls.csv"
         src_vehicle_group_names = ["da", "s2",  "s3",  "vsm", "sml", "med", "lrg"]
@@ -517,7 +519,7 @@
         value_of_time = 18.93
         operating_cost_per_mile = 17.23
         toll = [ "@bridgetoll_da" ]
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SOV_GP_{period}"
@@ -537,7 +539,7 @@
         operating_cost_per_mile = 17.23
         toll = [ "@bridgetoll_sr2" ]
         toll_factor = 0.5714285714285714
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "hovdist",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "hovdist","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR2_GP_{period}"
@@ -562,7 +564,7 @@
         operating_cost_per_mile = 17.23
         toll = ["@bridgetoll_sr3"]
         toll_factor = 0.4
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "hovdist",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "hovdist","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR3_GP_{period}"
@@ -620,7 +622,7 @@
         value_of_time = 18.93
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_da", "@bridgetoll_da" ]
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da", "valuetoll_da", "tolldist",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da", "valuetoll_da", "tolldist","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SOV_PAY_{period}"
@@ -637,7 +639,7 @@
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_sr2", "@bridgetoll_sr2" ]
         toll_factor = 0.5714285714285714
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "valuetoll_sr2", "hovdist", "tolldist",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "valuetoll_sr2", "hovdist", "tolldist","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR2_PAY_{period}"
@@ -655,7 +657,7 @@
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_sr3", "@bridgetoll_sr3" ]
         toll_factor = 0.4
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "valuetoll_sr3", "hovdist", "tolldist",]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "valuetoll_sr3", "hovdist", "tolldist","rlbty","autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR3_PAY_{period}"

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -35,8 +35,32 @@
     use_emme_logbook = true
 
 [household]
-    highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}.omx"
-    transit_demand_file = "demand_matrices/transit/TAP_Demand_{set}_{period}.omx"
+    highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}_{iter}.omx"
+    transit_demand_file = "demand_matrices/transit/TAP_Demand_{set}_{period}_{iter}.omx"
+    highway_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_{period}.omx"
+    highway_maz_ctramp_output_file = "ctramp_output/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
+    transit_tap_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{set}_{period}.omx"
+    [[household.mode_agg]]
+        name = "auto"
+        modes = [
+            "SOV_GP",
+            "SOV_PAY",
+            "SR2_GP",
+            "SR2_HOV",
+            "SR2_PAY",
+            "SR3_GP",
+            "SR3_HOV",
+            "SR3_PAY",
+        ]
+    [[household.mode_agg]]
+        name = "nonmotor"
+        modes = ["BIKE", "WALK"]
+    [[household.mode_agg]]
+        name = "other"
+        modes = ["SCHLBUS", "TAXI", "TNC"]
+    [[household.mode_agg]]
+        name = "transit"
+        modes = ["KNRPRV", "KNRTNC", "PNR", "WLK"]
 
 [air_passenger]
     output_trip_table_directory = "demand_matrices/highway/air_passenger"
@@ -495,11 +519,12 @@
         value_of_time = 17.23
         output_skim_file = "skim_matrices/highway/HWYSKIM_MAZMAZ_DA.csv"
         skim_period = "md"
+        max_distance = 10
         max_skim_cost = 11.0
             # based on ~= 5 miles @ 40 mph = 11
             #           = time + (0.6 / vot) * (dist * opcost)
             #           = 5 / 40 * 60 + (0.6 / 17.23) * (5 * 18.93)
-        demand_file = "demand_matrices/highway/maz_demand/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
+        demand_file = "demand_matrices/highway/maz_demand/auto_{period}_MAZ_AUTO_{number}_{period}_{iter}.omx"
         [[highway.maz_to_maz.demand_county_groups]]
             number = 1
             counties = ["San Francisco", "San Mateo", "Santa Clara"]
@@ -519,7 +544,7 @@
         value_of_time = 18.93
         operating_cost_per_mile = 17.23
         toll = [ "@bridgetoll_da" ]
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SOV_GP_{period}"
@@ -539,7 +564,7 @@
         operating_cost_per_mile = 17.23
         toll = [ "@bridgetoll_sr2" ]
         toll_factor = 0.5714285714285714
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "hovdist","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "hovdist", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR2_GP_{period}"
@@ -564,7 +589,7 @@
         operating_cost_per_mile = 17.23
         toll = ["@bridgetoll_sr3"]
         toll_factor = 0.4
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "hovdist","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "hovdist", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR3_GP_{period}"
@@ -622,7 +647,7 @@
         value_of_time = 18.93
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_da", "@bridgetoll_da" ]
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da", "valuetoll_da", "tolldist","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_da", "valuetoll_da", "tolldist", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SOV_PAY_{period}"
@@ -639,10 +664,18 @@
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_sr2", "@bridgetoll_sr2" ]
         toll_factor = 0.5714285714285714
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "valuetoll_sr2", "hovdist", "tolldist","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr2", "valuetoll_sr2", "hovdist", "tolldist", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR2_PAY_{period}"
+            factor = 0.5714285714285714
+        [[highway.classes.demand]]
+            source = "household"
+            name = "TAXI_{period}"
+            factor = 0.5714285714285714
+        [[highway.classes.demand]]
+            source = "household"
+            name = "TNC_{period}"
             factor = 0.5714285714285714
         [[highway.classes.demand]]
             source = "internal_external"
@@ -657,7 +690,7 @@
         operating_cost_per_mile = 17.23
         toll = [ "@valuetoll_sr3", "@bridgetoll_sr3" ]
         toll_factor = 0.4
-        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "valuetoll_sr3", "hovdist", "tolldist","rlbty","autotime"]
+        skims = [ "time", "dist", "freeflowtime", "bridgetoll_sr3", "valuetoll_sr3", "hovdist", "tolldist", "rlbty", "autotime"]
         [[highway.classes.demand]]
             source = "household"
             name = "SR3_PAY_{period}"
@@ -723,7 +756,7 @@
     #input_connector_access_times_path = "inputs\\trn\\estimated_taz_access_connectors.csv"
     #input_connector_egress_times_path = "inputs\\trn\\estimated_taz_egress_connectors.csv"
     #output_stop_usage_path = "inputs\\trn\\stop_usage_{period}.csv"
-    use_ccr = false
+    use_ccr = true
     ccr_stop_criteria.max_iterations = 3
     ccr_stop_criteria.relative_difference = 0.01
     ccr_stop_criteria.percent_segments_over_capacity = 0.01
@@ -741,13 +774,16 @@
         mode_types = ["ACCESS", "EGRESS", "WALK", "LOCAL"]
         [[transit.classes.demand]]
             source = "household"
-            name = "WLK_SET_{period}"
+            name = "WLK_TRN_set1_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "PNR_SET_{period}"
+            name = "PNR_TRN_set1_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "KNR_SET_{period}"
+            name = "KNRPRV_TRN_set1_{period}"
+        [[transit.classes.demand]]
+            source = "household"
+            name = "KNRTNC_TRN_set1_{period}"
     [[transit.classes]]
         skim_set_id = "SET2"
         name = "PREM"
@@ -755,13 +791,16 @@
         mode_types = ["ACCESS", "EGRESS", "WALK", "PREMIUM"]
         [[transit.classes.demand]]
             source = "household"
-            name = "WLK_SET_{period}"
+            name = "WLK_TRN_set2_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "PNR_SET_{period}"
+            name = "PNR_TRN_set2_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "KNR_SET_{period}"
+            name = "KNRPRV_TRN_set2_{period}"
+        [[transit.classes.demand]]
+            source = "household"
+            name = "KNRTNC_TRN_set2_{period}"
     [[transit.classes]]
         skim_set_id = "SET3"
         name = "ALLPEN"
@@ -770,13 +809,16 @@
         required_mode_combo = ["LOCAL","PREMIUM"] # AND not or
         [[transit.classes.demand]]
             source = "household"
-            name = "WLK_SET_{period}"
+            name = "WLK_TRN_set3_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "PNR_SET_{period}"
+            name = "PNR_TRN_set3_{period}"
         [[transit.classes.demand]]
             source = "household"
-            name = "KNR_SET_{period}"
+            name = "KNRPRV_TRN_set3_{period}"
+        [[transit.classes.demand]]
+            source = "household"
+            name = "KNRTNC_TRN_set3_{period}"
 
 [emme]
     num_processors = "MAX-1"

--- a/tm2py/components/demand/commercial.py
+++ b/tm2py/components/demand/commercial.py
@@ -559,7 +559,7 @@ class CommercialVehicleTripDistribution(Subcomponent):
         Returns:
             NumpyArray: Zone-by-zone matrix of friction factors
         """
-        if not self._friction_factor_matrices.get(trk_class):
+        if trk_class not in self._friction_factor_matrices.keys():
             self._friction_factor_matrices[
                 trk_class
             ] = self._calculate_friction_factor_matrix(

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -146,7 +146,7 @@ class HouseholdModel(Component):
                     self.controller.get_abs_path(self.config.transit_demand_file)
                     .__str__()
                     .format(
-                        period=period, iter="_%s" % self.controller.iteration, set=set
+                        period=period, iter=self.controller.iteration, set=set
                     )
                 )
                 output_omx = omx.open_file(output_path, "w")

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -145,9 +145,7 @@ class HouseholdModel(Component):
                 output_path = (
                     self.controller.get_abs_path(self.config.transit_demand_file)
                     .__str__()
-                    .format(
-                        period=period, iter=self.controller.iteration, set=set
-                    )
+                    .format(period=period, iter=self.controller.iteration, set=set)
                 )
                 output_omx = omx.open_file(output_path, "w")
                 for mode_agg in self.config.mode_agg:

--- a/tm2py/components/demand/prepare_demand.py
+++ b/tm2py/components/demand/prepare_demand.py
@@ -51,6 +51,7 @@ class EmmeDemand:
         """
         with OMXManager(path, "r") as omx_file:
             demand = omx_file.read(name)
+            omx_file.close()
         if factor is not None:
             demand = factor * demand
         demand = self._redim_demand(demand, num_zones)

--- a/tm2py/components/demand/prepare_demand.py
+++ b/tm2py/components/demand/prepare_demand.py
@@ -209,7 +209,11 @@ class PrepareHighwayDemand(EmmeDemand):
         path = self.controller.get_abs_path(
             self.controller.config[source].highway_demand_file
         ).__str__()
-        return self._read(path.format(period=time_period), name, num_zones)
+        return self._read(
+            path.format(period=time_period, iter=self.controller.iteration),
+            name,
+            num_zones,
+        )
 
 
 class PrepareTransitDemand(EmmeDemand):
@@ -300,5 +304,9 @@ class PrepareTransitDemand(EmmeDemand):
             self.controller.config[source].transit_demand_file
         ).__str__()
         return self._read(
-            path.format(period=time_period, set=skim_set), name, num_zones
+            path.format(
+                period=time_period, set=skim_set, iter=self.controller.iteration
+            ),
+            name,
+            num_zones,
         )

--- a/tm2py/components/demand/toll_choice.py
+++ b/tm2py/components/demand/toll_choice.py
@@ -288,6 +288,8 @@ class TollChoiceCalculator(Subcomponent):
             _util = self.utility[prop] * _skim_values * property_factors.get(prop, 1)
             _util_sum.append(_util)
 
+        self._omx_manager.close()  # can comment out
+
         return np.exp(np.add(*_util_sum))
 
     def mask_non_available(
@@ -331,5 +333,7 @@ class TollChoiceCalculator(Subcomponent):
 
         prob_nontoll[(toll_tollcost == 0) | (toll_tollcost > 999999)] = 1.0
         prob_nontoll[(nontoll_time == 0) | (nontoll_time > 999999)] = 0.0
+
+        self._omx_manager.close()
 
         return prob_nontoll

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -108,6 +108,33 @@ class CreateTODScenarios(Component):
         emmebank.extra_function_parameters.el1 = "@free_flow_time"
         emmebank.extra_function_parameters.el2 = "@capacity"
         emmebank.extra_function_parameters.el3 = "@ja"
+        emmebank.extra_function_parameters.el4 = "@static_rel"
+        reliability_tmplt = (
+            "* (1 + el4 + "
+            "( {factor[LOS_C]} * ( put(get(1).min.1.5) - {threshold[LOS_C]} + 0.01 ) ) * (get(1) .gt. {threshold[LOS_C]})"
+            "+ ( {factor[LOS_D]} * ( get(2) - {threshold[LOS_D]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_D]})"
+            "+ ( {factor[LOS_E]} * ( get(2) - {threshold[LOS_E]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_E]})"
+            "+ ( {factor[LOS_FL]} * ( get(2) - {threshold[LOS_FL]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FL]})"
+            "+ ( {factor[LOS_FH]} * ( get(2) - {threshold[LOS_FH]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FH]})"
+            ")")
+        parameters = {
+            "freeway": {
+                "factor": {
+                    "LOS_C": 0.2429, "LOS_D": 0.1705, "LOS_E": -0.2278, "LOS_FL": -0.1983, "LOS_FH": 1.022
+                },
+                "threshold": {
+                    "LOS_C": 0.7, "LOS_D": 0.8,  "LOS_E": 0.9, "LOS_FL": 1.0, "LOS_FH": 1.2
+                },
+            },
+            "road": {   # for arterials, ramps, collectors, local roads, etc.
+                "factor": {
+                    "LOS_C": 0.1561, "LOS_D": 0.0, "LOS_E": 0.0, "LOS_FL": -0.449, "LOS_FH": 0.0
+                },
+                "threshold": {
+                    "LOS_C": 0.7, "LOS_D": 0.8,  "LOS_E": 0.9, "LOS_FL": 1.0, "LOS_FH": 1.2
+                },
+            }
+        }
         # TODO: should have just 3 functions, and map the FT to the vdf
         # TODO: could optimize expression (to review)
         bpr_tmplt = "el1 * (1 + 0.20 * ((volau + volad)/el2/0.75)^6)"
@@ -119,10 +146,10 @@ class CreateTODScenarios(Component):
             # "(el1 + 60 * (0.25 *(put(put((volau + volad)/el2) - 1) + "
             # "(((get(2)*get(2) + (16 * el3 * get(1)^0.5))))"
         )
-        for f_id in ["fd1", "fd2", "fd9"]:
+        for f_id in ["fd1", "fd2"]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)
-            emmebank.create_function(f_id, bpr_tmplt)
+            emmebank.create_function(f_id, bpr_tmplt + reliability_tmplt.format(**parameters["freeway"]))
         for f_id in [
             "fd3",
             "fd4",
@@ -138,7 +165,7 @@ class CreateTODScenarios(Component):
         ]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)
-            emmebank.create_function(f_id, akcelik_tmplt)
+            emmebank.create_function(f_id, akcelik_tmplt + reliability_tmplt.format(**parameters["road"]))
         if emmebank.function("fd8"):
             emmebank.delete_function("fd8")
         emmebank.create_function("fd8", fixed_tmplt)

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -116,24 +116,41 @@ class CreateTODScenarios(Component):
             "+ ( {factor[LOS_E]} * ( get(2) - {threshold[LOS_E]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_E]})"
             "+ ( {factor[LOS_FL]} * ( get(2) - {threshold[LOS_FL]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FL]})"
             "+ ( {factor[LOS_FH]} * ( get(2) - {threshold[LOS_FH]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FH]})"
-            ")")
+            ")"
+        )
         parameters = {
             "freeway": {
                 "factor": {
-                    "LOS_C": 0.2429, "LOS_D": 0.1705, "LOS_E": -0.2278, "LOS_FL": -0.1983, "LOS_FH": 1.022
+                    "LOS_C": 0.2429,
+                    "LOS_D": 0.1705,
+                    "LOS_E": -0.2278,
+                    "LOS_FL": -0.1983,
+                    "LOS_FH": 1.022,
                 },
                 "threshold": {
-                    "LOS_C": 0.7, "LOS_D": 0.8,  "LOS_E": 0.9, "LOS_FL": 1.0, "LOS_FH": 1.2
+                    "LOS_C": 0.7,
+                    "LOS_D": 0.8,
+                    "LOS_E": 0.9,
+                    "LOS_FL": 1.0,
+                    "LOS_FH": 1.2,
                 },
             },
-            "road": {   # for arterials, ramps, collectors, local roads, etc.
+            "road": {  # for arterials, ramps, collectors, local roads, etc.
                 "factor": {
-                    "LOS_C": 0.1561, "LOS_D": 0.0, "LOS_E": 0.0, "LOS_FL": -0.449, "LOS_FH": 0.0
+                    "LOS_C": 0.1561,
+                    "LOS_D": 0.0,
+                    "LOS_E": 0.0,
+                    "LOS_FL": -0.449,
+                    "LOS_FH": 0.0,
                 },
                 "threshold": {
-                    "LOS_C": 0.7, "LOS_D": 0.8,  "LOS_E": 0.9, "LOS_FL": 1.0, "LOS_FH": 1.2
+                    "LOS_C": 0.7,
+                    "LOS_D": 0.8,
+                    "LOS_E": 0.9,
+                    "LOS_FL": 1.0,
+                    "LOS_FH": 1.2,
                 },
-            }
+            },
         }
         # TODO: should have just 3 functions, and map the FT to the vdf
         # TODO: could optimize expression (to review)
@@ -149,7 +166,9 @@ class CreateTODScenarios(Component):
         for f_id in ["fd1", "fd2"]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)
-            emmebank.create_function(f_id, bpr_tmplt + reliability_tmplt.format(**parameters["freeway"]))
+            emmebank.create_function(
+                f_id, bpr_tmplt + reliability_tmplt.format(**parameters["freeway"])
+            )
         for f_id in [
             "fd3",
             "fd4",
@@ -165,7 +184,9 @@ class CreateTODScenarios(Component):
         ]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)
-            emmebank.create_function(f_id, akcelik_tmplt + reliability_tmplt.format(**parameters["road"]))
+            emmebank.create_function(
+                f_id, akcelik_tmplt + reliability_tmplt.format(**parameters["road"])
+            )
         if emmebank.function("fd8"):
             emmebank.delete_function("fd8")
         emmebank.create_function("fd8", fixed_tmplt)

--- a/tm2py/components/network/highway/drive_access_skims.py
+++ b/tm2py/components/network/highway/drive_access_skims.py
@@ -231,6 +231,7 @@ class DriveAccessSkims(Component):
                     "DTIME": src_file.read(f"{period.name.upper()}_da_time").flatten(),
                 }
             )
+            src_file.close()
         # drop externals
         drive_costs = drive_costs[~drive_costs["FTAZ"].isin(externals)]
         drive_costs = drive_costs[~drive_costs["TTAZ"].isin(externals)]

--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -163,27 +163,39 @@ class HighwayAssignment(Component):
                 net_calc = NetworkCalculator(self.controller, scenario)
 
                 exf_pars = scenario.emmebank.extra_function_parameters
-                vdfs = [f for f in scenario.emmebank.functions() if f.type == "VOLUME_DELAY"]
+                vdfs = [
+                    f for f in scenario.emmebank.functions() if f.type == "VOLUME_DELAY"
+                ]
                 for function in vdfs:
                     expression = function.expression
                     for el in ["el1", "el2", "el3", "el4"]:
                         expression = expression.replace(el, getattr(exf_pars, el))
                     if "@static_rel" in expression:
                         # split function into time component and reliability component
-                        time_expr, reliability_expr = expression.split("*(1+@static_rel+")
-                        net_calc("@auto_time", time_expr, {"link": "vdf=%s" % function.id[2:]})
-                        net_calc("@reliability", "(@static_rel+" + reliability_expr, 
-                            {"link": "vdf=%s" % function.id[2:]})
+                        time_expr, reliability_expr = expression.split(
+                            "*(1+@static_rel+"
+                        )
+                        net_calc(
+                            "@auto_time",
+                            time_expr,
+                            {"link": "vdf=%s" % function.id[2:]},
+                        )
+                        net_calc(
+                            "@reliability",
+                            "(@static_rel+" + reliability_expr,
+                            {"link": "vdf=%s" % function.id[2:]},
+                        )
                         net_calc("@reliability_sq", "@reliability**2", {"link": "all"})
 
                 with self.logger.log_start_end(
-                    "Run SOLA assignment with path analyses and highway reliability", level="INFO"
+                    "Run SOLA assignment with path analyses and highway reliability",
+                    level="INFO",
                 ):
                     assign = self.controller.emme_manager.tool(
                         "inro.emme.traffic_assignment.sola_traffic_assignment"
                     )
                     assign(assign_spec, scenario, chart_log_interval=1)
-                
+
                 # Subtract non-time costs from gen cost to get the raw travel time
                 for emme_class_spec in assign_spec["classes"]:
                     self._calc_time_skim(emme_class_spec)
@@ -388,7 +400,7 @@ class HighwayAssignment(Component):
                 f"{data.mean():9.4g} {data.sum(): 13.7g}"
             )
             self.logger.debug(stats)
-    
+
 
 class AssignmentClass:
     """Highway assignment class, represents data from config and conversion to Emme specs."""
@@ -550,7 +562,7 @@ class AssignmentClass:
             "freeflowtime": "@free_flow_time",
             "bridgetoll": f"@bridgetoll_{group}",
             "valuetoll": f"@valuetoll_{group}",
-            "rlbty" : "@reliability_sq",
-            "autotime" : "@auto_time",
+            "rlbty": "@reliability_sq",
+            "autotime": "@auto_time",
         }
         return lookup[skim]

--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -173,7 +173,8 @@ class HighwayAssignment(Component):
                         time_expr, reliability_expr = expression.split("*(1+@static_rel+")
                         net_calc("@auto_time", time_expr, {"link": "vdf=%s" % function.id[2:]})
                         net_calc("@reliability", "(@static_rel+" + reliability_expr, 
-                                {"link": "vdf=%s" % function.id[2:]})
+                            {"link": "vdf=%s" % function.id[2:]})
+                        net_calc("@reliability_sq", "@reliability**2", {"link": "all"})
 
                 with self.logger.log_start_end(
                     "Run SOLA assignment with path analyses and highway reliability", level="INFO"
@@ -549,7 +550,7 @@ class AssignmentClass:
             "freeflowtime": "@free_flow_time",
             "bridgetoll": f"@bridgetoll_{group}",
             "valuetoll": f"@valuetoll_{group}",
-            "rlbty" : "@reliability",
+            "rlbty" : "@reliability_sq",
             "autotime" : "@auto_time",
         }
         return lookup[skim]

--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -133,7 +133,7 @@ class HighwayAssignment(Component):
     def run(self):
         """Run highway assignment."""
         demand = PrepareHighwayDemand(self.controller)
-        if self.controller.iteration >= 1:
+        if self.controller.iteration >= 0:
             demand.run()
         else:
             self.highway_emmebank.zero_matrix
@@ -149,7 +149,9 @@ class HighwayAssignment(Component):
                 else:
                     self._reset_background_traffic(scenario)
                 self._create_skim_matrices(scenario, assign_classes)
-                assign_spec = self._get_assignment_spec(assign_classes)
+                assign_spec = self._get_assignment_spec(
+                    assign_classes, path_analysis=False
+                )
                 # self.logger.log_dict(assign_spec, level="DEBUG")
                 with self.logger.log_start_end(
                     "Run SOLA assignment with path analyses", level="INFO"
@@ -187,6 +189,9 @@ class HighwayAssignment(Component):
                         )
                         net_calc("@reliability_sq", "@reliability**2", {"link": "all"})
 
+                assign_spec = self._get_assignment_spec(
+                    assign_classes, path_analysis=True
+                )
                 with self.logger.log_start_end(
                     "Run SOLA assignment with path analyses and highway reliability",
                     level="INFO",
@@ -282,7 +287,7 @@ class HighwayAssignment(Component):
                     self._skim_matrices.append(matrix)
 
     def _get_assignment_spec(
-        self, assign_classes: List[AssignmentClass]
+        self, assign_classes: List[AssignmentClass], path_analysis=True
     ) -> EmmeTrafficAssignmentSpec:
         """Generate template Emme SOLA assignment specification.
 
@@ -314,6 +319,10 @@ class HighwayAssignment(Component):
                 "number_of_processors": self.controller.num_processors
             },
         }
+        if not path_analysis:
+            base_spec["classes"] = [
+                klass.emme_highway_class_spec_wo_pa for klass in assign_classes
+            ]
         return base_spec
 
     def _calc_time_skim(self, emme_class_spec: EmmeHighwayClassSpec):
@@ -346,7 +355,7 @@ class HighwayAssignment(Component):
             skims: list of requested skims (from config)
         """
         for skim_name in skims:
-            if skim_name in ["time", "distance", "freeflowtime", "hovdist", "tolldist"]:
+            if skim_name in ["time", "dist", "freeflowtime", "hovdist", "tolldist"]:
                 matrix_name = f"mf{time_period}_{class_name}_{skim_name}"
                 self.logger.debug(f"Setting intrazonals to 0.5*min for {matrix_name}")
                 data = self._matrix_cache.get_data(matrix_name)
@@ -450,6 +459,39 @@ class AssignmentClass:
                 },
             },
             "path_analyses": self.emme_class_analysis,
+        }
+        return class_spec
+
+    @property
+    def emme_highway_class_spec_wo_pa(self) -> EmmeHighwayClassSpec:
+        """Construct and return Emme traffic assignment class specification.
+
+        Converted from input config (highway.classes), see Emme Help for
+        SOLA traffic assignment for specification details.
+        Adds time_period as part of demand and skim matrix names.
+
+        Returns:
+            A nested dictionary corresponding to the expected Emme traffic
+            class specification used in the SOLA assignment.
+        """
+        if self.iteration == 0:
+            demand_matrix = 'ms"zero"'
+        else:
+            demand_matrix = f'mf"{self.time_period}_{self.name}"'
+        class_spec = {
+            "mode": self.class_config.mode_code,
+            "demand": demand_matrix,
+            "generalized_cost": {
+                "link_costs": f"@cost_{self.name.lower()}",  # cost in $0.01
+                # $/hr -> min/$0.01
+                "perception_factor": 0.6 / self.class_config.value_of_time,
+            },
+            "results": {
+                "link_volumes": f"@flow_{self.name.lower()}",
+                "od_travel_times": {
+                    "shortest_paths": f"mf{self.time_period}_{self.name}_time"
+                },
+            },
         }
         return class_spec
 

--- a/tm2py/components/network/highway/highway_maz.py
+++ b/tm2py/components/network/highway/highway_maz.py
@@ -334,6 +334,7 @@ class AssignMAZSPDemand(Component):
         self.logger.log(f"Reading demand from {omx_file_path}", level="DEBUG")
         with OMXManager(omx_file_path, "r") as omx_file:
             demand_array = omx_file.read(f"MAZ_AUTO_{index}_{time}")
+            omx_file.close()
         return demand_array
 
     def _group_demand(

--- a/tm2py/components/network/highway/highway_maz.py
+++ b/tm2py/components/network/highway/highway_maz.py
@@ -222,15 +222,33 @@ class AssignMAZSPDemand(Component):
             f"Processing county MAZs for {', '.join(counties)}", level="DETAIL"
         )
         network = self._network
+        # maz data
+        # maz_file = self.get_abs_path(self.controller.config.scenario.maz_landuse_file)
+        # maz_df = pd.read_csv(maz_file)
+        # maz_county_dict = dict(zip(maz_df["MAZ_ORIGINAL"], maz_df["CountyName"]))
         # NOTE: every maz must have a valid #node_county
         if self._mazs is None:
             self._mazs = _defaultdict(lambda: [])
             for node in network.nodes():
                 if node["@maz_id"]:
+                    # self._mazs[maz_county_dict[node["@maz_id"]]].append(node)
                     self._mazs[node["#node_county"]].append(node)
         mazs = []
         for county in counties:
             mazs.extend(self._mazs[county])
+        # highway emme network does not include the 5 inaccessiable MAZs, but the trip table is indexed by the full MAZ list
+        # https://app.asana.com/0/12291104512575/1199091221400653/f
+        if "San Francisco" in counties:
+            mazs.extend(
+                [
+                    {"@maz_id": 10186},
+                    {"@maz_id": 16084},
+                    {"@maz_id": 111432},
+                    {"@maz_id": 111433},
+                ]
+            )
+        if "Contra Costa" in counties:
+            mazs.extend([{"@maz_id": 411178}])
         self.logger.log(f"Num MAZs {len(mazs)}", level="DEBUG")
         return sorted(mazs, key=lambda n: n["@maz_id"])
 
@@ -261,11 +279,30 @@ class AssignMAZSPDemand(Component):
             # skip intra-maz demand
             if orig == dest:
                 continue
+            if orig > len(maz_ids) - 1:
+                self.logger.log(
+                    f"Network MAZ @maz_id={orig} #county_name does not match its county name in the input MAZ SE data.",
+                    level="DEBUG",
+                )
+                continue
+            if dest > len(maz_ids) - 1:
+                self.logger.log(
+                    f"Network MAZ @maz_id={dest} #county_name does not match its county name in the input MAZ SE data.",
+                    level="DEBUG",
+                )
+                continue
+            check = maz_ids[99]
             orig_node = maz_ids[orig]
             dest_node = maz_ids[dest]
             dist = _sqrt(
                 (dest_node.x - orig_node.x) ** 2 + (dest_node.y - orig_node.y) ** 2
             )
+            if (dist / 5280) > self.config.max_distance:
+                self.logger.log(
+                    f"MAZ demand from {orig} to {dest} is over {self.config.max_distance} miles, do not assign",
+                    level="DEBUG",
+                )
+                continue
             if dist > self._max_dist:
                 self._max_dist = dist
             demand = data[orig][dest]
@@ -290,11 +327,13 @@ class AssignMAZSPDemand(Component):
         """
         file_path_tmplt = self.get_abs_path(self.config.demand_file)
         omx_file_path = self.get_abs_path(
-            file_path_tmplt.format(period=time, number=index)
+            file_path_tmplt.format(
+                period=time, number=index, iter=self.controller.iteration
+            )
         )
         self.logger.log(f"Reading demand from {omx_file_path}", level="DEBUG")
         with OMXManager(omx_file_path, "r") as omx_file:
-            demand_array = omx_file.read("M0")
+            demand_array = omx_file.read(f"MAZ_AUTO_{index}_{time}")
         return demand_array
 
     def _group_demand(

--- a/tm2py/components/network/highway/highway_network.py
+++ b/tm2py/components/network/highway/highway_network.py
@@ -153,6 +153,7 @@ class PrepareNetwork(Component):
                 ("@intdist_up", "dist from the closest upstream int"),
                 ("@static_rel", "static reliability"),
                 ("@reliability", "link total reliability"),
+                ("@reliability_sq", "link total reliability variance"),
                 ("@auto_time", "link total reliability"),
             ],
             "NODE": [

--- a/tm2py/components/network/highway/highway_network.py
+++ b/tm2py/components/network/highway/highway_network.py
@@ -462,11 +462,17 @@ class PrepareNetwork(Component):
             check_far_node = lambda l: l.i_node.is_interchange
         # Shortest path search for nearest interchange node along freeway
         for link in get_links(orig_link):
-            _heapq.heappush(heap, (link["length"], link))
+            _heapq.heappush(heap, (link["length"], link["#link_id"], link))
         interchange_found = False
+
+        # Check first node
+        if check_far_node(orig_link):
+            interchange_found = True
+            link_cost = 0.0
+        
         try:
             while not interchange_found:
-                link_cost, link = _heapq.heappop(heap)
+                link_cost, link_id, link = _heapq.heappop(heap)
                 if link in visited:
                     continue
                 visited_add(link)
@@ -478,7 +484,11 @@ class PrepareNetwork(Component):
                     if next_link in visited:
                         continue
                     next_cost = link_cost + next_link["length"]
-                    _heapq.heappush(heap, (next_cost, next_link))
+                    _heapq.heappush(heap, (next_cost, next_link["#link_id"], next_link))
+        except TypeError:
+            # TypeError if the link type objects are compared in the tuples
+            # case where the path cost are the same
+            raise Exception("Path cost are the same, cannot compare Link objects")
         except IndexError:
             # IndexError if heap is empty
             # case where start / end of highway, dist = 99

--- a/tm2py/components/network/highway/highway_network.py
+++ b/tm2py/components/network/highway/highway_network.py
@@ -49,9 +49,13 @@ The following attributes are calculated:
 import os
 from typing import TYPE_CHECKING, Dict, List, Set
 
+import pandas as pd
+
 from tm2py.components.component import Component, FileFormatError
 from tm2py.emme.manager import EmmeNetwork, EmmeScenario
 from tm2py.logger import LogStartEnd
+
+import heapq as _heapq
 
 if TYPE_CHECKING:
     from tm2py.controller import RunController
@@ -87,6 +91,8 @@ class PrepareNetwork(Component):
                 self._set_link_modes(network)
                 self._calc_link_skim_lengths(network)
                 self._calc_link_class_costs(network)
+                self._calc_interchange_distance(network)
+                self._calc_link_static_reliability(network)
                 scenario.publish_network(network)
 
     @property
@@ -143,6 +149,14 @@ class PrepareNetwork(Component):
                 ("@maz_flow", "Assigned MAZ-to-MAZ flow"),
                 ("@hov_length", "length with HOV lanes"),
                 ("@toll_length", "length with tolls"),
+                ("@intdist_down", "dist to the closest d-stream interchange"),
+                ("@intdist_up", "dist from the closest upstream int"),
+                ("@static_rel", "static reliability"),
+                ("@reliability", "link total reliability"),
+                ("@auto_time", "link total reliability"),
+            ],
+            "NODE": [
+                ("@interchange", "interchange"),
             ]
         }
         # toll field attributes by bridge and value and toll definition
@@ -387,3 +401,138 @@ class PrepareNetwork(Component):
                 except:
                     link
                 link[cost_attr] = link.length * op_cost + toll_value * toll_factor
+
+    def _calc_interchange_distance(self, network: EmmeNetwork):
+        """
+        For highway reliability
+        Calculate upstream and downstream interchange distance
+        First, label the intersection nodes as nodes with freeway and freeway-to-freeway ramp
+        """
+        # input interchange nodes file
+        # This is a file inherited from https://app.box.com/folder/148342877307, as implemented in the tm2.1
+        interchange_nodes_file = self.get_abs_path(self.config.interchange_nodes_file)
+        interchange_nodes_df = pd.read_csv(interchange_nodes_file)
+        interchange_nodes_df = interchange_nodes_df[interchange_nodes_df.intx > 0]
+        interchange_points = interchange_nodes_df["N"].tolist()
+        network.create_attribute("NODE", "is_interchange")
+        for node in network.nodes():
+            if node["#node_id"] in interchange_points:
+                node.is_interchange = True
+                node["@interchange"] = node.is_interchange
+        # The following approach is based on SANDAG's code
+        # network.create_attribute("NODE", "is_interchange")
+        # interchange_points = []
+        # mode_c = network.mode('c')
+        # for node in network.nodes():
+        #     adj_links = list(node.incoming_links()) + list(node.outgoing_links())
+        #     has_freeway_links = bool(
+        #         [l for l in adj_links
+        #             if l["@ft"] in [1,2] and mode_c in l.modes])
+        #     has_ramp_links = bool(
+        #         [l for l in adj_links
+        #             if l["@ft"] == 3 and mode_c in l.modes])
+        #     if has_freeway_links and has_ramp_links:
+        #         node.is_interchange = True
+        #         interchange_points.append(node)
+        #     else:
+        #         node.is_interchange = False
+        # for node in network.nodes():
+        #     node["@interchange"] = node.is_interchange
+        
+        mode_c = network.mode('c')
+        for link in network.links():
+            if link["@ft"] in [1,2] and mode_c in link.modes:
+                link["@intdist_down"] = PrepareNetwork.interchange_distance(link, "DOWNSTREAM")
+                link["@intdist_up"] = PrepareNetwork.interchange_distance(link, "UPSTREAM")
+        
+        network.delete_attribute("NODE", "is_interchange")
+    
+    @staticmethod
+    def interchange_distance(orig_link, direction):
+        visited = set([])
+        visited_add = visited.add
+        back_links = {}
+        heap = []
+        if direction == "DOWNSTREAM":
+            get_links = lambda l: l.j_node.outgoing_links()
+            check_far_node = lambda l: l.j_node.is_interchange
+        elif direction == "UPSTREAM":
+            get_links = lambda l: l.i_node.incoming_links()
+            check_far_node = lambda l: l.i_node.is_interchange
+        # Shortest path search for nearest interchange node along freeway
+        for link in get_links(orig_link):
+            _heapq.heappush(heap, (link["length"], link))
+        interchange_found = False
+        try:
+            while not interchange_found:
+                link_cost, link = _heapq.heappop(heap)
+                if link in visited:
+                    continue
+                visited_add(link)
+                if check_far_node(link):
+                    interchange_found = True
+                    break
+                get_links_return = get_links(link)
+                for next_link in get_links_return:
+                    if next_link in visited:
+                        continue
+                    next_cost = link_cost + next_link["length"]
+                    _heapq.heappush(heap, (next_cost, next_link))
+        except IndexError:
+            # IndexError if heap is empty
+            # case where start / end of highway, dist = 99
+            return 99
+        return orig_link["length"] / 2.0 + link_cost
+
+    def _calc_link_static_reliability(self, network: EmmeNetwork):
+        """
+        For highway reliability
+        consists of: lane factor, interchange distance, speed factor
+        differentiated by freeway, artertial, and others
+        """
+        # Static reliability parameters
+        # freeway coefficients
+        freeway_rel = {
+            "intercept": 0.1078,
+            "speed>70": 0.01393,
+            "upstream": 0.011,
+            "downstream": 0.0005445,
+        }
+        # arterial/ramp/other coefficients
+        road_rel = {
+            "intercept": 0.0546552,
+            "lanes": {
+                1: 0.0,
+                2: 0.0103589,
+                3: 0.0361211,
+                4: 0.0446958,
+                5: 0.0
+            },
+            "speed":  {
+                "<35": 0,
+                35: 0.0075674,
+                40: 0.0091012,
+                45: 0.0080996,
+                50: -0.0022938,
+                ">50": -0.0046211
+            },
+        }
+        for link in network.links():
+            # if freeway apply freeway parameters to this link
+            if (link["@ft"] in [1,2]) and (link['@lanes'] > 0):
+                high_speed_factor = freeway_rel["speed>70"] if link["@free_flow_speed"]>=70 else 0
+                upstream_factor = freeway_rel["upstream"] * 1 / link["@intdist_up"]
+                downstream_factor = freeway_rel["downstream"] * 1 / link["@intdist_down"]
+                link["@static_rel"] = freeway_rel["intercept"] + high_speed_factor + upstream_factor + downstream_factor
+            # arterial/ramp/other apply road parameters
+            elif (link["@ft"] < 8) and (link["@lanes"] > 0):
+                lane_factor = road_rel["lanes"].get(link["@lanes"],0)
+                speed_bin = link["@free_flow_speed"]
+                if speed_bin < 35:
+                    speed_bin = "<35"
+                elif speed_bin > 50:
+                    speed_bin = ">50"
+                speed_factor = road_rel["speed"][speed_bin]
+                link["@static_rel"] = road_rel["intercept"] + lane_factor + speed_factor
+            else:
+                link["@static_rel"] = 0

--- a/tm2py/components/network/skims.py
+++ b/tm2py/components/network/skims.py
@@ -97,7 +97,7 @@ def get_omx_skim_as_numpy(
             )
 
     _matrix_name = _config.output_skim_matrixname_tmpl.format(
-        time_period=time_period.lower(),
+        time_period=time_period.upper(),
         mode=skim_mode,
         property=property,
     )
@@ -110,26 +110,22 @@ def get_omx_skim_as_numpy(
         )
         _filepath = controller.run_dir / _config.output_skim_path / _filename
         with OMXManager(_filepath, "r") as _f:
-            return _f.read(_matrix_name)
+            omx_data = _f.read(_matrix_name)
+            _f.close()
+            return omx_data
     else:
-        if omx_manager._omx_file is None:
-            if not omx_manager._file_path.endswith(".omx"):
-                _filename = _config.output_skim_filename_tmpl.format(
-                    time_period=time_period.lower()
-                )
-                omx_manager._file_path = os.path.join(omx_manager._file_path, _filename)
-            omx_manager.open()
-        else:
-            _filename = _config.output_skim_filename_tmpl.format(
-                time_period=time_period.lower()
+        _filename = _config.output_skim_filename_tmpl.format(
+            time_period=time_period.lower()
+        )
+        if os.path.basename(omx_manager._file_path) != _filename:
+            omx_manager.close()
+            omx_manager._file_path = (
+                controller.run_dir / _config.output_skim_path / _filename
             )
-            if os.path.basename(omx_manager._file_path) != _filename:
-                omx_manager.close()
-                omx_manager._file_path = (
-                    controller.run_dir / _config.output_skim_path / _filename
-                )
-                omx_manager.open()
-        return omx_manager.read(_matrix_name)
+        omx_manager.open()
+        omx_data = omx_manager.read(_matrix_name)
+        omx_manager.close()
+        return omx_data
 
 
 def get_blended_skim(

--- a/tm2py/components/network/transit/transit_assign.py
+++ b/tm2py/components/network/transit/transit_assign.py
@@ -467,7 +467,7 @@ class TransitAssignment(Component):
         """Run transit assignments."""
 
         use_ccr = False
-        if self.controller.iteration >= 0: #TODO add option of warmstart
+        if self.controller.iteration >= 0:  # TODO add option of warmstart
             use_ccr = self.config.use_ccr
 
             self.sub_components["prepare transit demand"].run()

--- a/tm2py/components/network/transit/transit_assign.py
+++ b/tm2py/components/network/transit/transit_assign.py
@@ -467,7 +467,7 @@ class TransitAssignment(Component):
         """Run transit assignments."""
 
         use_ccr = False
-        if self.controller.iteration >= 1:
+        if self.controller.iteration >= 0: #TODO add option of warmstart
             use_ccr = self.config.use_ccr
 
             self.sub_components["prepare transit demand"].run()
@@ -984,8 +984,8 @@ class TransitAssignmentClass:
 
     @property
     def _demand_matrix(self) -> str:
-        if self._iteration < 1:
-            return 'ms"zero"'  # zero demand matrix
+        # if self._iteration < 1:
+        #     return 'ms"zero"'  # zero demand matrix
         return f'mf"TRN_{self._class_config.skim_set_id}_{self._time_period}"'
 
     def _get_used_mode_ids(self, modes: List[TransitModeConfig]) -> List[str]:

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -259,11 +259,29 @@ class TimeOfDayConfig(ConfigItem):
 
 
 @dataclass(frozen=True)
+class HouseholdModeAgg(ConfigItem):
+    """household trip mode aggregation input parameters.
+
+    Properties:
+        name: aggregate name used for the class group in the input columns
+            for the trip tables,
+        modes: list of mode choice mode names used for the trip tables
+    """
+
+    name: str
+    modes: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class HouseholdConfig(ConfigItem):
     """Household (residents) model parameters."""
 
     highway_demand_file: pathlib.Path
     transit_demand_file: pathlib.Path
+    highway_taz_ctramp_output_file: pathlib.Path
+    mode_agg: List[HouseholdModeAgg]
+    highway_maz_ctramp_output_file: pathlib.Path
+    transit_tap_ctramp_output_file: pathlib.Path
 
 
 @dataclass(frozen=True)
@@ -823,6 +841,7 @@ class HighwayMazToMazConfig(ConfigItem):
     mode_code: str = Field(min_length=1, max_length=1)
     value_of_time: float = Field(gt=0)
     operating_cost_per_mile: float = Field(ge=0)
+    max_distance: float = Field(gt=0)
     max_skim_cost: float = Field(gt=0)
     excluded_links: Tuple[str, ...] = Field()
     demand_file: pathlib.Path = Field()

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -877,6 +877,7 @@ class HighwayConfig(ConfigItem):
     maz_to_maz: HighwayMazToMazConfig = Field()
     classes: Tuple[HighwayClassConfig, ...] = Field()
     capclass_lookup: Tuple[HighwayCapClassConfig, ...] = Field()
+    interchange_nodes_file: str = Field()
 
     @validator("output_skim_filename_tmpl")
     def valid_skim_template(value):
@@ -947,7 +948,7 @@ class HighwayConfig(ConfigItem):
         """Validate classes .skims, .toll, and .excluded_links values."""
         if "tolls" not in values:
             return value
-        avail_skims = ["time", "dist", "hovdist", "tolldist", "freeflowtime"]
+        avail_skims = ["time", "dist", "hovdist", "tolldist", "freeflowtime","rlbty","autotime"]
         available_link_sets = ["is_sr", "is_sr2", "is_sr3", "is_auto_only"]
         avail_toll_attrs = []
         for name in values["tolls"].dst_vehicle_group_names:

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -948,7 +948,15 @@ class HighwayConfig(ConfigItem):
         """Validate classes .skims, .toll, and .excluded_links values."""
         if "tolls" not in values:
             return value
-        avail_skims = ["time", "dist", "hovdist", "tolldist", "freeflowtime","rlbty","autotime"]
+        avail_skims = [
+            "time",
+            "dist",
+            "hovdist",
+            "tolldist",
+            "freeflowtime",
+            "rlbty",
+            "autotime",
+        ]
         available_link_sets = ["is_sr", "is_sr2", "is_sr3", "is_auto_only"]
         avail_toll_attrs = []
         for name in values["tolls"].dst_vehicle_group_names:


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?

1. Added step `_consolidate_demand_for_assign()` in household.py to prepare ctramp demand into the format assignment expects, while retaining the trip tables from each global iteration
2. Fixed a bug in highway maz auto assignment, on MAZ index miss-match between the trip table (full size MAZs) and the highway network MAZ nodes (missing 5 disconnected MAZs - https://app.asana.com/0/12291104512575/1199091221400653/f)


## What is the testing plan?

*Demonstrate the code is solid by discussing how results are verified and covered by tests*

 - [ ] Code for this PR is covered in tests 
 - [ ] Code passes all existing tests

## Code formatting
*Code should be PEP8 compliant before merging by running a package like [`black`](https://pypi.org/project/black/)*

 - [ ] Code linted

## Applicable Issues

 
#### Issues List

 -  closes...
 -  closes...


