### PR TITLE
Bring in BART Transit Fixes/Improvements

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -756,7 +756,7 @@
     #input_connector_access_times_path = "inputs\\trn\\estimated_taz_access_connectors.csv"
     #input_connector_egress_times_path = "inputs\\trn\\estimated_taz_egress_connectors.csv"
     #output_stop_usage_path = "inputs\\trn\\stop_usage_{period}.csv"
-    use_ccr = true
+    use_ccr = false
     ccr_stop_criteria.max_iterations = 3
     ccr_stop_criteria.relative_difference = 0.01
     ccr_stop_criteria.percent_segments_over_capacity = 0.01
@@ -1413,6 +1413,20 @@
 	critical_speed = 3.0
 
 [[transit.modes]]
+    mode_id = "D"
+    name = "drive_acc"
+    description = "drive_acc"
+    type = "DRIVE"
+    assign_type = "AUX_TRANSIT"
+    speed_miles_per_hour = 30.0
+[[transit.modes]]
+    mode_id = "k"
+    name = "knrdummy"
+    description = "knrdummy"
+    type = "KNR_dummy"
+    assign_type = "AUX_TRANSIT"
+    speed_miles_per_hour = 40.0
+[[transit.modes]]
     mode_id = "w"
     name = "walk"
     description = "walk"
@@ -1433,6 +1447,13 @@
     type = "EGRESS"
     assign_type = "AUX_TRANSIT"
     speed_miles_per_hour = 3.0
+[[transit.modes]]
+    mode_id = "p"
+    name = "pnrdummy"
+    description = "pnrdummy"
+    type = "PNR_dummy"
+    assign_type = "TRANSIT"
+    in_vehicle_perception_factor = 1.0
 [[transit.modes]]
     mode_id = "b"
     description = "local_bus"
@@ -1480,283 +1501,283 @@
     assign_type = "TRANSIT"
     in_vehicle_perception_factor = 1.0
 
-[[transit.vehicles]]
-    vehicle_id = 12
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 14
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 13
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 16
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 17
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 20
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 21
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 24
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 28
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 30
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 38
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 42
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 44
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 46
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 49
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 52
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 56
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 60
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 63
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 66
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 68
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 70
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 71
-    mode = "b"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 80
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 81
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 84
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 86
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 87
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 90
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 91
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 92
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 94
-    mode = "x"
-    name = ""
-    auto_equivalent = 2.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 101
-    mode = "f"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 103
-    mode = "f"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 110
-    mode = "l"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 111
-    mode = "l"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 120
-    mode = "h"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 130
-    mode = "r"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 131
-    mode = "r"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
-[[transit.vehicles]]
-    vehicle_id = 133
-    mode = "r"
-    name = ""
-    auto_equivalent = 0.0
-    seated_capacity = 1
-    total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 12
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 14
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 13
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 16
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 17
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 20
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 21
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 24
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 28
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 30
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 38
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 42
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 44
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 46
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 49
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 52
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 56
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 60
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 63
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 66
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 68
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 70
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 71
+#     mode = "b"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 80
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 81
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 84
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 86
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 87
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 90
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 91
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 92
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 94
+#     mode = "x"
+#     name = ""
+#     auto_equivalent = 2.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 101
+#     mode = "f"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 103
+#     mode = "f"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 110
+#     mode = "l"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 111
+#     mode = "l"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 120
+#     mode = "h"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 130
+#     mode = "r"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 131
+#     mode = "r"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2
+# [[transit.vehicles]]
+#     vehicle_id = 133
+#     mode = "r"
+#     name = ""
+#     auto_equivalent = 0.0
+#     seated_capacity = 1
+#     total_capacity = 2

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -7,26 +7,31 @@
     length_hours = 3
     highway_capacity_factor = 3
     emme_scenario_id = 11
+    congested_transit_assn_max_iteration = 1
 [[time_periods]]
     name = "am"
     length_hours = 4
     highway_capacity_factor = 3.65
     emme_scenario_id = 12
+    congested_transit_assn_max_iteration = 10
 [[time_periods]]
     name = "md"
     length_hours = 5
     highway_capacity_factor = 5
     emme_scenario_id = 13
+    congested_transit_assn_max_iteration = 1
 [[time_periods]]
     name = "pm"
     length_hours = 4
     highway_capacity_factor = 3.65
     emme_scenario_id = 14
+    congested_transit_assn_max_iteration = 10
 [[time_periods]]
     name = "ev"
     length_hours = 8
     highway_capacity_factor = 8
     emme_scenario_id = 15
+    congested_transit_assn_max_iteration = 1
 
 [logging]
     # Use default log configuration
@@ -736,26 +741,33 @@
 
 [transit]
     apply_msa_demand = false
-    value_of_time = 16.2
+    # vot=16.2*(180.20/227.47) https://github.com/BayAreaMetro/modeling-website/wiki/InflationAssumptions
+    value_of_time = 12.8
+    walk_speed = 3.0
+    # default transit speed used to calculate transit time in case any links has missing time from highway network
+    transit_speed = 30.0 
     effective_headway_source = "hdw"
     initial_wait_perception_factor = 1.5
     transfer_wait_perception_factor = 3.0
     walk_perception_factor = 2.0
+    walk_perception_factor_cbd = 1.0
+    drive_perception_factor = 3.0
     initial_boarding_penalty = 10
     transfer_boarding_penalty = 10
     max_transfers = 3
-    output_skim_path = "skim_matrices/transit/transit_skims_{period}.omx"
+    # fare option
+    use_fares = true
+    fare_2015_to_2000_deflator = 0.698 #180.20/258.27
     fares_path = "inputs/trn/fares.far"
     fare_matrix_path = "inputs/trn/fareMatrix.txt"
     # max expected transfer distance for mode-to-mode transfer fare table generation
     fare_max_transfer_distance_miles = 3.0
-    use_fares = false
     # for TAZ instead of TAPs
     ## set to true if use TAZ
     override_connector_times = false
     #input_connector_access_times_path = "inputs\\trn\\estimated_taz_access_connectors.csv"
     #input_connector_egress_times_path = "inputs\\trn\\estimated_taz_egress_connectors.csv"
-    #output_stop_usage_path = "inputs\\trn\\stop_usage_{period}.csv"
+    # capacitated transit assignment methods
     use_ccr = false
     ccr_stop_criteria.max_iterations = 3
     ccr_stop_criteria.relative_difference = 0.01
@@ -767,6 +779,32 @@
     ccr_weights.max_stand = 1.6
     ccr_weights.power_stand = 3.4
     eawt_weights.constant = 0.259625
+    # congested transit assignment methods
+    congested_transit_assignment = true
+    congested.trim_demand_before_congested_transit_assignment = true
+    congested.output_trimmed_demand_report_path = "output_summaries/trimmed_demand_{period}_{iteration}.csv"
+    congested.normalized_gap = 0.25
+    congested.relative_gap = 0.005
+    congested.use_peaking_factor = true
+    congested.am_peaking_factor = 1.219
+    congested.pm_peaking_factor = 1.262
+    # output skim and summary paths
+    output_skim_path = "skim_matrices/transit/transit_skims_{period}.omx"
+    # output_skim_path = "skims/transit"
+    output_skim_filename_tmpl = "trnskm{time_period}_{set_name}.omx"
+    output_skim_matrixname_tmpl = "{property}"
+    output_stop_usage_path = "output_summaries/stop_usage_{period}.csv"
+    output_transit_boardings_path = "output_summaries/boardings_by_line_{period}.csv"
+    output_transit_segment_path = "output_summaries/transit_segment_{period}.csv"
+    output_station_to_station_flow_path = "output_summaries/{operator}_station_to_station_{set_name}_{period}.txt"
+    output_transfer_at_station_path = "output_summaries/{set_name}_transfer_at_{stop}_{period}"
+    # timed tranfer nodes
+    timed_transfer_nodes = [2625944, 2625943] # standard network #node_id of Bart stations: 19th street, MacArthur
+    [transit.output_transfer_at_station_node_ids]
+        "12th_street"=2625945 # standard network #node_id
+        "19th street"=2625944 
+        "MacArthur"=2625943
+
     [[transit.classes]]
         skim_set_id = "SET1"
         name = "BUS"
@@ -1418,35 +1456,35 @@
     description = "drive_acc"
     type = "DRIVE"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 30.0
+    speed_or_time_factor = "ul1*1"
 [[transit.modes]]
     mode_id = "k"
     name = "knrdummy"
     description = "knrdummy"
     type = "KNR_dummy"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 40.0
+    speed_or_time_factor = 40.0
 [[transit.modes]]
     mode_id = "w"
     name = "walk"
     description = "walk"
     type = "WALK"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "a"
     name = "access"
     description = "access"
     type = "ACCESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "e"
     name = "egress"
     description = "egress"
     type = "EGRESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "p"
     name = "pnrdummy"
@@ -1454,6 +1492,10 @@
     type = "PNR_dummy"
     assign_type = "TRANSIT"
     in_vehicle_perception_factor = 1.0
+    initial_boarding_penalty = 2.0
+    transfer_boarding_penalty = 2.0
+    headway_fraction = 0.5
+    transfer_wait_perception_factor = 3
 [[transit.modes]]
     mode_id = "b"
     description = "local_bus"
@@ -1461,6 +1503,10 @@
     type = "LOCAL"
     assign_type = "TRANSIT"
     in_vehicle_perception_factor = 1.0
+    initial_boarding_penalty = 10.0
+    transfer_boarding_penalty = 10.0
+    headway_fraction = 0.5
+    transfer_wait_perception_factor = 3
 [[transit.modes]]
     mode_id = "x"
     description = "exp_bus"
@@ -1468,6 +1514,10 @@
     type = "PREMIUM"
     assign_type = "TRANSIT"
     in_vehicle_perception_factor = 1.0
+    initial_boarding_penalty = 10.0
+    transfer_boarding_penalty = 10.0
+    headway_fraction = 0.5
+    transfer_wait_perception_factor = 3
     eawt_factor = 0.4
 [[transit.modes]]
     mode_id = "f"
@@ -1475,7 +1525,11 @@
     name = "FR"
     type = "PREMIUM"
     assign_type = "TRANSIT"
-    in_vehicle_perception_factor = 1.0
+    in_vehicle_perception_factor = 0.8
+    initial_boarding_penalty = 2.0
+    transfer_boarding_penalty = 2.0
+    headway_fraction = 0.1
+    transfer_wait_perception_factor = 0.1
     eawt_factor = 0.2
 [[transit.modes]]
     mode_id = "l"
@@ -1483,7 +1537,11 @@
     name = "LR"
     type = "PREMIUM"
     assign_type = "TRANSIT"
-    in_vehicle_perception_factor = 1.0
+    in_vehicle_perception_factor = 0.9
+    initial_boarding_penalty = 7.0
+    transfer_boarding_penalty = 7.0
+    headway_fraction = 0.5
+    transfer_wait_perception_factor = 3
     eawt_factor = 0.4
 [[transit.modes]]
     mode_id = "h"
@@ -1491,7 +1549,11 @@
     name = "HR"
     type = "PREMIUM"
     assign_type = "TRANSIT"
-    in_vehicle_perception_factor = 1.0
+    in_vehicle_perception_factor = 0.7
+    initial_boarding_penalty = 5.0
+    transfer_boarding_penalty = 5.0
+    headway_fraction = 0.5
+    transfer_wait_perception_factor = 3
     eawt_factor = 0.2
 [[transit.modes]]
     mode_id = "r"
@@ -1499,7 +1561,11 @@
     name = "CR"
     type = "PREMIUM"
     assign_type = "TRANSIT"
-    in_vehicle_perception_factor = 1.0
+    in_vehicle_perception_factor = 0.7
+    initial_boarding_penalty = 5.0
+    transfer_boarding_penalty = 5.0
+    headway_fraction = 0.3
+    transfer_wait_perception_factor = 3
 
 # [[transit.vehicles]]
 #     vehicle_id = 12

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -41,7 +41,8 @@
 
 [household]
     highway_demand_file = "demand_matrices/highway/household/TAZ_Demand_{period}_{iter}.omx"
-    transit_demand_file = "demand_matrices/transit/TAP_Demand_{set}_{period}_{iter}.omx"
+    # transit_demand_file = "demand_matrices/transit/TAP_Demand_{set}_{period}_{iter}.omx"
+    transit_demand_file = "demand_matrices/transit/trn_demand_v9_trim_{period}.omx" #temp
     highway_taz_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_{period}.omx"
     highway_maz_ctramp_output_file = "ctramp_output/auto_{period}_MAZ_AUTO_{number}_{period}.omx"
     transit_tap_ctramp_output_file = "ctramp_output/{mode_agg}_{period}_{mode}_TRN_{set}_{period}.omx"
@@ -752,8 +753,6 @@
     walk_perception_factor = 2.0
     walk_perception_factor_cbd = 1.0
     drive_perception_factor = 3.0
-    initial_boarding_penalty = 10
-    transfer_boarding_penalty = 10
     max_transfers = 3
     # fare option
     use_fares = true
@@ -788,16 +787,22 @@
     congested.use_peaking_factor = true
     congested.am_peaking_factor = 1.219
     congested.pm_peaking_factor = 1.262
+    congested_weights.min_seat = 1.0
+    congested_weights.max_seat = 1.4
+    congested_weights.power_seat = 2.2
+    congested_weights.min_stand = 1.4
+    congested_weights.max_stand = 1.6
+    congested_weights.power_stand = 3.4    
     # output skim and summary paths
     output_skim_path = "skim_matrices/transit/transit_skims_{period}.omx"
     # output_skim_path = "skims/transit"
     output_skim_filename_tmpl = "trnskm{time_period}_{set_name}.omx"
     output_skim_matrixname_tmpl = "{property}"
-    output_stop_usage_path = "output_summaries/stop_usage_{period}.csv"
-    output_transit_boardings_path = "output_summaries/boardings_by_line_{period}.csv"
-    output_transit_segment_path = "output_summaries/transit_segment_{period}.csv"
-    output_station_to_station_flow_path = "output_summaries/{operator}_station_to_station_{set_name}_{period}.txt"
-    output_transfer_at_station_path = "output_summaries/{set_name}_transfer_at_{stop}_{period}"
+    # output_stop_usage_path = "output_summaries/stop_usage_{period}.csv"
+    # output_transit_boardings_path = "output_summaries/boardings_by_line_{period}.csv"
+    # output_transit_segment_path = "output_summaries/transit_segment_{period}.csv"
+    # output_station_to_station_flow_path = "output_summaries/{operator}_station_to_station_{set_name}_{period}.txt"
+    # output_transfer_at_station_path = "output_summaries/{set_name}_transfer_at_{stop}_{period}"
     # timed tranfer nodes
     timed_transfer_nodes = [2625944, 2625943] # standard network #node_id of Bart stations: 19th street, MacArthur
     [transit.output_transfer_at_station_node_ids]
@@ -806,57 +811,45 @@
         "MacArthur"=2625943
 
     [[transit.classes]]
-        skim_set_id = "SET1"
-        name = "BUS"
-        description = "Local bus"
-        mode_types = ["ACCESS", "EGRESS", "WALK", "LOCAL"]
-        [[transit.classes.demand]]
-            source = "household"
-            name = "WLK_TRN_set1_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "PNR_TRN_set1_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "KNRPRV_TRN_set1_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "KNRTNC_TRN_set1_{period}"
-    [[transit.classes]]
-        skim_set_id = "SET2"
-        name = "PREM"
-        description = "Premium modes"
-        mode_types = ["ACCESS", "EGRESS", "WALK", "PREMIUM"]
-        [[transit.classes.demand]]
-            source = "household"
-            name = "WLK_TRN_set2_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "PNR_TRN_set2_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "KNRPRV_TRN_set2_{period}"
-        [[transit.classes.demand]]
-            source = "household"
-            name = "KNRTNC_TRN_set2_{period}"
-    [[transit.classes]]
-        skim_set_id = "SET3"
-        name = "ALLPEN"
-        description = "All w/ xfer pen"
+        skim_set_id = "WLK_TRN_WLK"
+        name = "WLK_TRN_WLK"
+        description = "walk access and walk egress"
         mode_types = ["ACCESS", "EGRESS", "WALK", "LOCAL", "PREMIUM"]
-        required_mode_combo = ["LOCAL","PREMIUM"] # AND not or
         [[transit.classes.demand]]
             source = "household"
-            name = "WLK_TRN_set3_{period}"
+            name = "WLK_TRN_WLK"
+    [[transit.classes]]
+        skim_set_id = "PNR_TRN_WLK"
+        name = "PNR_TRN_WLK"
+        description = "PNR access and walk egress"
+        mode_types = ["DRIVE", "PNR_dummy", "WALK", "EGRESS", "LOCAL", "PREMIUM"]
         [[transit.classes.demand]]
             source = "household"
-            name = "PNR_TRN_set3_{period}"
+            name = "PNR_TRN_WLK"
+    [[transit.classes]]
+        skim_set_id = "WLK_TRN_PNR"
+        name = "WLK_TRN_PNR"
+        description = "walk access and PNR egress"
+        mode_types = ["ACCESS", "WALK", "DRIVE", "PNR_dummy", "LOCAL", "PREMIUM"]
         [[transit.classes.demand]]
             source = "household"
-            name = "KNRPRV_TRN_set3_{period}"
+            name = "WLK_TRN_PNR"
+    [[transit.classes]]
+        skim_set_id = "KNR_TRN_WLK"
+        name = "KNR_TRN_WLK"
+        description = "KNR access and walk egress"
+        mode_types = ["DRIVE", "KNR_dummy", "WALK", "EGRESS", "LOCAL", "PREMIUM"]
         [[transit.classes.demand]]
             source = "household"
-            name = "KNRTNC_TRN_set3_{period}"
+            name = "KNR_TRN_WLK"
+    [[transit.classes]]
+        skim_set_id = "WLK_TRN_KNR"
+        name = "WLK_TRN_KNR"
+        description = "walk access and KNR egress"
+        mode_types = ["ACCESS", "WALK", "DRIVE", "KNR_dummy", "LOCAL", "PREMIUM"]
+        [[transit.classes.demand]]
+            source = "household"
+            name = "WLK_TRN_KNR"
 
 [emme]
     num_processors = "MAX-1"

--- a/tm2py/components/demand/prepare_demand.py
+++ b/tm2py/components/demand/prepare_demand.py
@@ -306,7 +306,9 @@ class PrepareTransitDemand(EmmeDemand):
         ).__str__()
         return self._read(
             path.format(
-                period=time_period, set=skim_set, iter=self.controller.iteration
+                period=time_period, 
+                # set=skim_set, 
+                # iter=self.controller.iteration
             ),
             name,
             num_zones,

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -247,7 +247,16 @@ class CreateTODScenarios(Component):
                     "@free_flow_speed",
                     "@free_flow_time",
                 ],
-                "TRANSIT_LINE": ["@invehicle_factor"],
+                "TRANSIT_LINE": [
+                    "@invehicle_factor",
+                    "@iboard_penalty",
+                    "@xboard_penalty"
+                ],
+                "NODE": [
+                    "@hdw_fraction",
+                    "@wait_pfactor",
+                    "@xboard_nodepen"
+                ]
             }
             for domain, attrs in attributes.items():
                 for name in attrs:
@@ -273,14 +282,40 @@ class CreateTODScenarios(Component):
 
             mode_table = self.controller.config.transit.modes
             in_vehicle_factors = {}
+            initial_boarding_penalty = {}
+            transfer_boarding_penalty = {}
+            headway_fraction = {}
+            transfer_wait_perception_factor = {}
+
             default_in_vehicle_factor = self.controller.config.transit.get(
                 "in_vehicle_perception_factor", 1.0
             )
-            walk_modes = set()
-            access_modes = set()
-            egress_modes = set()
-            local_modes = set()
-            premium_modes = set()
+            default_initial_boarding_penalty = self.controller.config.transit.get(
+                "initial_boarding_penalty", 10
+            )
+            default_transfer_boarding_penalty = self.controller.config.transit.get(
+                "transfer_boarding_penalty", 10
+            )
+            default_headway_fraction = self.controller.config.transit.get(
+                "headway_fraction", 0.5
+            )
+            default_transfer_wait_perception_factor = self.controller.config.transit.get(
+                "transfer_wait_perception_factor", 1
+            )
+            walk_perception_factor = self.controller.config.transit.get(
+                "walk_perception_factor", 2
+            )
+            walk_perception_factor_cbd = self.controller.config.transit.get(
+                "walk_perception_factor_cbd", 1
+            )
+            drive_perception_factor = self.controller.config.transit.get(
+                "drive_perception_factor", 2
+            )
+            # walk_modes = set()
+            # access_modes = set()
+            # egress_modes = set()
+            # local_modes = set()
+            # premium_modes = set()
             for mode_data in mode_table:
                 mode = network.mode(mode_data["mode_id"])
                 if mode is None:
@@ -292,21 +327,33 @@ class CreateTODScenarios(Component):
                         f"mode {mode_data['id']} already exists with type {mode.type} instead of {mode_data['assign_type']}"
                     )
                 mode.description = mode_data["name"]
-                if mode_data["assign_type"] == "AUX_TRANSIT":
-                    mode.speed = mode_data["speed_miles_per_hour"]
-                if mode_data["type"] == "WALK":
-                    walk_modes.add(mode.id)
-                elif mode_data["type"] == "ACCESS":
-                    access_modes.add(mode.id)
-                elif mode_data["type"] == "EGRESS":
-                    egress_modes.add(mode.id)
-                elif mode_data["type"] == "LOCAL":
-                    local_modes.add(mode.id)
-                elif mode_data["type"] == "PREMIUM":
-                    premium_modes.add(mode.id)
+                if mode_data['assign_type'] == "AUX_TRANSIT":
+                    if mode_data['type'] == "DRIVE":
+                        mode.speed = "ul1*%s" % drive_perception_factor
+                    else:
+                        mode.speed = mode_data['speed_or_time_factor']
+                # if mode_data["assign_type"] == "AUX_TRANSIT":
+                #     mode.speed = mode_data["speed_miles_per_hour"]
+                # if mode_data["type"] == "WALK":
+                #     walk_modes.add(mode.id)
+                # elif mode_data["type"] == "ACCESS":
+                #     access_modes.add(mode.id)
+                # elif mode_data["type"] == "EGRESS":
+                #     egress_modes.add(mode.id)
+                # elif mode_data["type"] == "LOCAL":
+                #     local_modes.add(mode.id)
+                # elif mode_data["type"] == "PREMIUM":
+                #     premium_modes.add(mode.id)
                 in_vehicle_factors[mode.id] = mode_data.get(
-                    "in_vehicle_perception_factor", default_in_vehicle_factor
-                )
+                    "in_vehicle_perception_factor", default_in_vehicle_factor)
+                initial_boarding_penalty[mode.id] = mode_data.get(
+                    "initial_boarding_penalty", default_initial_boarding_penalty)
+                transfer_boarding_penalty[mode.id] = mode_data.get(
+                    "transfer_boarding_penalty", default_transfer_boarding_penalty)
+                headway_fraction[mode.id] = mode_data.get(
+                    "headway_fraction", default_headway_fraction)
+                transfer_wait_perception_factor[mode.id] = mode_data.get(
+                    "transfer_wait_perception_factor", default_transfer_wait_perception_factor)
 
             # create vehicles
             # vehicle_table = self.controller.config.transit.vehicles
@@ -332,21 +379,31 @@ class CreateTODScenarios(Component):
                 "LRAIL": 30.0,
                 "FERRY": 15.0,
             }
+            walk_speed = self.controller.config.transit.get(
+                "walk_speed", 3.0
+                )
+            transit_speed = self.controller.config.transit.get(
+                "transit_speed", 30.0
+                )
             for link in network.links():
                 speed = cntype_speed_map.get(link["#cntype"])
                 if speed is None:
-                    speed = link["@free_flow_speed"]
+                    # speed = link["@free_flow_speed"]
+                    speed = 30.0 # temp fix, will uncomment it when bring in highway changes
                     if link["@ft"] == 1 and speed > 0:
                         link["@trantime"] = 60 * link.length / speed
                     elif speed > 0:
                         link["@trantime"] = (
                             60 * link.length / speed + link.length * 5 * 0.33
                         )
+                    else:
+                        link["@trantime"] = 60 * link.length / transit_speed
                 else:
                     link["@trantime"] = 60 * link.length / speed
-                # set TAP connector distance to 60 feet
-                if link.i_node.is_centroid or link.j_node.is_centroid:
-                    link.length = 0.01  # 60.0 / 5280.0
+                link.data1 = link["@trantime"]
+                # # set TAP connector distance to 60 feet
+                # if link.i_node.is_centroid or link.j_node.is_centroid:
+                #     link.length = 0.01  # 60.0 / 5280.0
             for line in network.transit_lines():
                 # TODO: may want to set transit line speeds (not necessarily used in the assignment though)
                 line_veh = network.transit_vehicle(line["#vehtype"]) # use #vehtype here instead of #mode (#vehtype is vehtype_num in Lasso\mtc_data\lookups\transitSeatCap.csv)
@@ -360,31 +417,72 @@ class CreateTODScenarios(Component):
                 line.vehicle = line_veh
                 # Set the perception factor from the mode table
                 line["@invehicle_factor"] = in_vehicle_factors[line.vehicle.mode.id]
+                line["@iboard_penalty"] = initial_boarding_penalty[line.vehicle.mode.id]
+                line["@xboard_penalty"] = transfer_boarding_penalty[line.vehicle.mode.id]
 
-            # set link modes to the minimum set
-            auto_mode = {self.controller.config.highway.generic_highway_mode_code}
+            # # set link modes to the minimum set
+            # auto_mode = {self.controller.config.highway.generic_highway_mode_code}
+            # for link in network.links():
+            #     # get used transit modes on link
+            #     modes = {seg.line.mode for seg in link.segments()}
+            #     # add in available modes based on link type
+            #     if link["@drive_link"]:
+            #         modes |= local_modes
+            #         modes |= auto_mode
+            #     if link["@bus_only"]:
+            #         modes |= local_modes
+            #     if link["@rail_link"] and not modes:
+            #         modes |= premium_modes
+            #     # add access, egress or walk mode (auxilary transit modes)
+            #     if link.i_node.is_centroid:
+            #         modes |= egress_modes
+            #     elif link.j_node.is_centroid:
+            #         modes |= access_modes
+            #     elif link["@walk_link"]:
+            #         modes |= walk_modes
+            #     if not modes:  # in case link is unused, give it the auto mode
+            #         link.modes = auto_mode
+            #     else:
+            #         link.modes = modes
             for link in network.links():
-                # get used transit modes on link
-                modes = {seg.line.mode for seg in link.segments()}
-                # add in available modes based on link type
-                if link["@drive_link"]:
-                    modes |= local_modes
-                    modes |= auto_mode
-                if link["@bus_only"]:
-                    modes |= local_modes
-                if link["@rail_link"] and not modes:
-                    modes |= premium_modes
-                # add access, egress or walk mode (auxilary transit modes)
-                if link.i_node.is_centroid:
-                    modes |= egress_modes
-                elif link.j_node.is_centroid:
-                    modes |= access_modes
-                elif link["@walk_link"]:
-                    modes |= walk_modes
-                if not modes:  # in case link is unused, give it the auto mode
-                    link.modes = auto_mode
+                # set default values
+                link.i_node['@hdw_fraction'] = default_headway_fraction
+                link.i_node['@wait_pfactor'] = default_transfer_wait_perception_factor
+                link.i_node['@xboard_nodepen'] = 1
+                link.j_node['@hdw_fraction'] = default_headway_fraction
+                link.j_node['@wait_pfactor'] = default_transfer_wait_perception_factor
+                link.j_node['@xboard_nodepen'] = 1               
+                # update modes on connectors
+                if (link.i_node.is_centroid) and (link["@drive_link"]==0):
+                    link.modes = "a"
+                elif (link.j_node.is_centroid) and (link["@drive_link"]==0):
+                    link.modes = "e"
+                elif (link.i_node.is_centroid or link.j_node.is_centroid ) and (link["@drive_link"]!=0):
+                    link.modes = set([network.mode('c'), network.mode('D')])  
+                # calculate perceived walk time
+                # perceived walk time will be used in walk mode definition "ul2", 
+                # link.data1 is used to save congested bus time, so use link.data2 here
+                if link["@area_type"] in [0,1]:
+                    link.data2 = 60 * link.length / (walk_speed / walk_perception_factor_cbd)
                 else:
-                    link.modes = modes
+                    link.data2 = 60 * link.length / (walk_speed / walk_perception_factor)
+
+            # set headway fraction, transfer wait perception and transfer boarding penalty at specific nodes
+            for line in network.transit_lines():
+                if line.vehicle.mode.id == "r":
+                    for seg in line.segments():
+                        seg.i_node['@hdw_fraction'] = headway_fraction[line.vehicle.mode.id]
+                        seg.j_node['@hdw_fraction'] = headway_fraction[line.vehicle.mode.id]
+                elif line.vehicle.mode.id == "f":
+                    for seg in line.segments():
+                        seg.i_node['@hdw_fraction'] = headway_fraction[line.vehicle.mode.id]
+                        seg.i_node['@wait_pfactor'] = transfer_wait_perception_factor[line.vehicle.mode.id]
+                        seg.j_node['@hdw_fraction'] = headway_fraction[line.vehicle.mode.id]
+                        seg.j_node['@wait_pfactor'] = transfer_wait_perception_factor[line.vehicle.mode.id]
+                elif line.vehicle.mode.id =="h":
+                    for seg in line.segments():
+                        if seg.i_node['#node_id'] in self.controller.config.transit.timed_transfer_nodes:
+                            seg.i_node['@xboard_nodepen'] = 0            
 
             ref_scenario.publish_network(network)
 

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -46,7 +46,7 @@ class CreateTODScenarios(Component):
         # emme_app = self._emme_manager.project(project_path)
         # self._emme_manager.init_modeller(emme_app)
         with self._setup():
-            self._create_highway_scenarios()
+            # self._create_highway_scenarios()
             self._create_transit_scenarios()
 
     @_context
@@ -221,7 +221,7 @@ class CreateTODScenarios(Component):
                 "scenarios": 1 + n_time_periods,
                 "regular_nodes": 650000,
                 "links": 1900000,
-                "transit_vehicles": 200,
+                "transit_vehicles": 600, # pnr vechiles
                 "transit_segments": 1800000,
                 "extra_attribute_values": 200000000,
             }
@@ -254,22 +254,22 @@ class CreateTODScenarios(Component):
                     if ref_scenario.extra_attribute(name) is None:
                         ref_scenario.create_extra_attribute(domain, name)
             network = ref_scenario.get_network()
-            auto_network = self._ref_auto_network
-            # copy link attributes from auto network to transit network
-            link_lookup = {}
-            for link in auto_network.links():
-                link_lookup[link["#link_id"]] = link
-            for link in network.links():
-                auto_link = link_lookup.get(link["#link_id"])
-                if not auto_link:
-                    continue
-                for attr in [
-                    "@area_type",
-                    "@capclass",
-                    "@free_flow_speed",
-                    "@free_flow_time",
-                ]:
-                    link[attr] = auto_link[attr]
+            # auto_network = self._ref_auto_network
+            # # copy link attributes from auto network to transit network
+            # link_lookup = {}
+            # for link in auto_network.links():
+            #     link_lookup[link["#link_id"]] = link
+            # for link in network.links():
+            #     auto_link = link_lookup.get(link["#link_id"])
+            #     if not auto_link:
+            #         continue
+            #     for attr in [
+            #         "@area_type",
+            #         "@capclass",
+            #         "@free_flow_speed",
+            #         "@free_flow_time",
+            #     ]:
+            #         link[attr] = auto_link[attr]
 
             mode_table = self.controller.config.transit.modes
             in_vehicle_factors = {}
@@ -309,20 +309,20 @@ class CreateTODScenarios(Component):
                 )
 
             # create vehicles
-            vehicle_table = self.controller.config.transit.vehicles
-            for veh_data in vehicle_table:
-                vehicle = network.transit_vehicle(veh_data["vehicle_id"])
-                if vehicle is None:
-                    vehicle = network.create_transit_vehicle(
-                        veh_data["vehicle_id"], veh_data["mode"]
-                    )
-                elif vehicle.mode.id != veh_data["mode"]:
-                    raise Exception(
-                        f"vehicle {veh_data['vehicle_id']} already exists with mode {vehicle.mode.id} instead of {veh_data['mode']}"
-                    )
-                vehicle.auto_equivalent = veh_data["auto_equivalent"]
-                vehicle.seated_capacity = veh_data["seated_capacity"]
-                vehicle.total_capacity = veh_data["total_capacity"]
+            # vehicle_table = self.controller.config.transit.vehicles
+            # for veh_data in vehicle_table:
+            #     vehicle = network.transit_vehicle(veh_data["vehicle_id"])
+            #     if vehicle is None:
+            #         vehicle = network.create_transit_vehicle(
+            #             veh_data["vehicle_id"], veh_data["mode"]
+            #         )
+            #     elif vehicle.mode.id != veh_data["mode"]:
+            #         raise Exception(
+            #             f"vehicle {veh_data['vehicle_id']} already exists with mode {vehicle.mode.id} instead of {veh_data['mode']}"
+            #         )
+            #     vehicle.auto_equivalent = veh_data["auto_equivalent"]
+            #     vehicle.seated_capacity = veh_data["seated_capacity"]
+            #     vehicle.total_capacity = veh_data["total_capacity"]
 
             # set fixed guideway times, and initial free flow auto link times
             # TODO: cntype_speed_map to config
@@ -349,10 +349,10 @@ class CreateTODScenarios(Component):
                     link.length = 0.01  # 60.0 / 5280.0
             for line in network.transit_lines():
                 # TODO: may want to set transit line speeds (not necessarily used in the assignment though)
-                line_veh = network.transit_vehicle(line["#mode"])
+                line_veh = network.transit_vehicle(line["#vehtype"]) # use #vehtype here instead of #mode (#vehtype is vehtype_num in Lasso\mtc_data\lookups\transitSeatCap.csv)
                 if line_veh is None:
                     raise Exception(
-                        f"line {line.id} requires vehicle ('#mode') {line['#mode']} which does not exist"
+                        f"line {line.id} requires vehicle ('#vehtype') {line['#vehtype']} which does not exist"
                     )
                 line_mode = line_veh.mode.id
                 for seg in line.segments():

--- a/tm2py/components/network/transit/transit_network.py
+++ b/tm2py/components/network/transit/transit_network.py
@@ -697,21 +697,21 @@ class ApplyFares(Component):
                 faresystems, faresystem_groups, network
             )
             self.save_journey_levels("ALLPEN", journey_levels)
-            local_modes = []
-            premium_modes = []
-            for mode in self.config.modes:
-                if mode.type == "LOCAL":
-                    local_modes.extend(mode_map[mode.mode_id])
-                if mode.type == "PREMIUM":
-                    premium_modes.extend(mode_map[mode.mode_id])
-            local_levels = self.filter_journey_levels_by_mode(
-                local_modes, journey_levels
-            )
-            self.save_journey_levels("BUS", local_levels)
-            premium_levels = self.filter_journey_levels_by_mode(
-                premium_modes, journey_levels
-            )
-            self.save_journey_levels("PREM", premium_levels)
+            # local_modes = []
+            # premium_modes = []
+            # for mode in self.config.modes:
+            #     if mode.type == "LOCAL":
+            #         local_modes.extend(mode_map[mode.mode_id])
+            #     if mode.type == "PREMIUM":
+            #         premium_modes.extend(mode_map[mode.mode_id])
+            # local_levels = self.filter_journey_levels_by_mode(
+            #     local_modes, journey_levels
+            # )
+            # self.save_journey_levels("BUS", local_levels)
+            # premium_levels = self.filter_journey_levels_by_mode(
+            #     premium_modes, journey_levels
+            # )
+            # self.save_journey_levels("PREM", premium_levels)
 
         except Exception as error:
             self._log.append({"type": "text", "content": "error during apply fares"})
@@ -1453,14 +1453,14 @@ class ApplyFares(Component):
         # transition rules will be the same for every journey level
         transition_rules = []
         journey_levels = [
-            {
-                "description": "base",
-                "destinations_reachable": True,
-                "transition_rules": transition_rules,
-                "waiting_time": None,
-                "boarding_time": None,
-                "boarding_cost": None,
-            }
+            # {
+            #     "description": "base",
+            #     "destinations_reachable": True,
+            #     "transition_rules": transition_rules,
+            #     "waiting_time": None,
+            #     "boarding_time": None,
+            #     "boarding_cost": None,
+            # }
         ]
         mode_map = _defaultdict(lambda: [])
         level = 1

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1009,7 +1009,7 @@ class HighwayConfig(ConfigItem):
 class TransitModeConfig(ConfigItem):
     """Transit mode definition (see also mode in the Emme API)."""
 
-    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM"]
+    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM", "DRIVE", "PNR_dummy","KNR_dummy"]
     assign_type: Literal["TRANSIT", "AUX_TRANSIT"]
     mode_id: str = Field(min_length=1, max_length=1)
     name: str = Field(max_length=10)
@@ -1044,9 +1044,9 @@ class TransitModeConfig(ConfigItem):
 class TransitVehicleConfig(ConfigItem):
     """Transit vehicle definition (see also transit vehicle in the Emme API)."""
 
-    vehicle_id: int
-    mode: str
-    name: str
+    vehicle_id: Optional[int] = Field(default=None, ge=0)
+    mode: Optional[str] = Field(default="")
+    name: Optional[str] = Field(default="")
     auto_equivalent: Optional[float] = Field(default=0, ge=0)
     seated_capacity: Optional[int] = Field(default=None, ge=0)
     total_capacity: Optional[int] = Field(default=None, ge=0)
@@ -1098,7 +1098,6 @@ class TransitConfig(ConfigItem):
     """Transit assignment parameters."""
 
     modes: Tuple[TransitModeConfig, ...]
-    vehicles: Tuple[TransitVehicleConfig, ...]
     classes: Tuple[TransitClassConfig, ...]
     value_of_time: float
     effective_headway_source: str
@@ -1125,7 +1124,7 @@ class TransitConfig(ConfigItem):
     input_connector_egress_times_path: Optional[str] = Field(default=None)
     output_stop_usage_path: Optional[str] = Field(default=None)
     output_transit_boardings_path: Optional[str] = Field(default=None)
-
+    vehicles: Optional[TransitVehicleConfig] = Field(default_factory=TransitVehicleConfig)
 
 @dataclass(frozen=True)
 class EmmeConfig(ConfigItem):

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1119,6 +1119,17 @@ class CcrWeightsConfig(ConfigItem):
 
 
 @dataclass(frozen=True)
+class CongestedWeightsConfig(ConfigItem):
+    "Weights for Congested Transit Assignment Configuration."
+    min_seat: float = Field(default=1.0)
+    max_seat: float = Field(default=1.4)
+    power_seat: float = Field(default=2.2)
+    min_stand: float = Field(default=1.4)
+    max_stand: float = Field(default=1.6)
+    power_stand: float = Field(default=3.4)
+
+
+@dataclass(frozen=True)
 class EawtWeightsConfig(ConfigItem):
     "Weights for calculating extra added wait time Configuration."
     constant: float = Field(default=0.259625)
@@ -1154,8 +1165,6 @@ class TransitConfig(ConfigItem):
     initial_wait_perception_factor: float
     transfer_wait_perception_factor: float
     walk_perception_factor: float
-    initial_boarding_penalty: float
-    transfer_boarding_penalty: float
     walk_perception_factor: float
     walk_perception_factor_cbd: float
     drive_perception_factor: float
@@ -1172,6 +1181,7 @@ class TransitConfig(ConfigItem):
     eawt_weights: EawtWeightsConfig
     congested_transit_assignment: bool
     congested: CongestedAssnConfig
+    congested_weights: CongestedWeightsConfig
     output_skim_path: pathlib.Path
     output_skim_filename_tmpl: str = Field()
     output_skim_matrixname_tmpl: str = Field()
@@ -1183,7 +1193,7 @@ class TransitConfig(ConfigItem):
     timed_transfer_nodes: Tuple[int, ...] = Field()
     output_transfer_at_station_node_ids: Dict[str, int] = Field()
     max_ccr_iterations: float = None
-    split_connectors_to_prevent_walk: bool = True
+    split_connectors_to_prevent_walk: bool = False
     input_connector_access_times_path: Optional[str] = Field(default=None)
     input_connector_egress_times_path: Optional[str] = Field(default=None)
     vehicles: Optional[TransitVehicleConfig] = Field(default_factory=TransitVehicleConfig)


### PR DESCRIPTION
TODO:
get model mechanically running with MTC version tm2py + BART version network
- [x] uncongested transit assignment went through
- [x] add extra parameters to configs
- [x] prepare transit network, add necessary attributes

Fare system:
- [x] update zone-to-zone fare calculation
- [x] update fare system grouping method
- [x] add fare_2015_to_2000_deflator

Skimming:
- [ ] skimming didn't work (Error: Current environment is inadequate to perform a parallel matrix calculation)
- [ ] add "CROWD","XBOATIME","DTOLL" skim
- [ ] multiply skim by 100 (except for XBOATIME and BOARD)
- [ ] divide walk/drive time skims by walk and drive perception factors 

Test congested transit assignment:
- [ ] add congested transit assignment method
- [x] update assignment specifications
- [ ] add customized segment congestion function
- [x] update demand tables (three sets --> five classes)
- [x] mixed-mode journey level files
- [ ] add trim demand option
- [ ] check the [zero_matrix](https://github.com/BayAreaMetro/tm2py/blob/develop/tm2py/emme/manager.py#L121) method. The zero demand initialization doesn't work, but won't affect the assignment test

Warmstart:
- [ ] add warmstart feature

Other features:
- [ ] peaking factors
- [ ] PNR parking penalties
- [ ] update bus time calculation
- [ ] add summaries (segment level report, trim demand report, bart-to-bart transfer, boardings at rail stations by access mode, transfer at stops)
- [ ] had some issues with the current summary report (output_stop_usage, export_boardings_by_line)

Validate assignment results:
- [ ] compare ridership to survey data