### PR TITLE
Fix transit travel time errors

### DIFF
--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -173,6 +173,7 @@ class CreateTODScenarios(Component):
             "fd3",
             "fd4",
             "fd5",
+            "fd6",
             "fd7",
             "fd9",
             "fd10",

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -342,6 +342,8 @@ class CreateTODScenarios(Component):
                         link["@trantime"] = (
                             60 * link.length / speed + link.length * 5 * 0.33
                         )
+                    else:
+                        link["@trantime"] = 0
                 else:
                     link["@trantime"] = 60 * link.length / speed
                 # set TAP connector distance to 60 feet
@@ -517,6 +519,8 @@ class CreateTODScenarios(Component):
             area_type = link["@area_type"]
             if area_type < 0:
                 link["@capclass"] = -1
+            elif (link["@ft"] == 99) & (link["@assignable"] == 1):
+                link["@capclass"] = 10 * area_type + 7
             else:
                 link["@capclass"] = 10 * area_type + link["@ft"]
 

--- a/tm2py/components/network/transit/transit_network.py
+++ b/tm2py/components/network/transit/transit_network.py
@@ -328,13 +328,17 @@ class PrepareTransitNetwork(Component):
         _highway_net = _highway_scenario.get_partial_network(
             ["LINK"], include_attributes=False
         )
-        travel_time_attributes = {"LINK": ["#link_id", "auto_time"]}
+        travel_time_attributes = {"LINK": ["#link_id", "auto_time", "@lanes"]}
         self.emme_manager.copy_attribute_values(
             _highway_scenario, _highway_net, travel_time_attributes
         )
         # TODO can we just get the link attributes as a DataFrame and merge them?
+        # if the link does not have meaningful travel time in highway assigned network
+        # such as bus only link, managed lanes, etc.
+        # assume default bus speed of 30 mph
         auto_link_time_dict = {
-            auto_link["#link_id"]: auto_link.auto_time
+            auto_link["#link_id"] : ( auto_link.auto_time
+            if auto_link["@lanes"] > 0 else 60*auto_link["length"]/30 )
             for auto_link in _highway_net.links()
         }
         return auto_link_time_dict


### PR DESCRIPTION
This PR solves:

- [x] Highway network has 0 capacity links, due to assignable links include some facility type 99 links
- [x] Assigned transit travel time has large values
