### PR TITLE
Force Transit Boarding in Path Builder (i.e., prohibit walk-all-the-way paths)

### DIFF
--- a/tm2py/components/network/transit/transit_assign.py
+++ b/tm2py/components/network/transit/transit_assign.py
@@ -2231,13 +2231,41 @@ class TransitAssignmentClass:
 
             elif self.name == "WLK_TRN_WLK":
                 new_journey_levels = copy.deepcopy(journey_levels)
-                transition_rules = copy.deepcopy(journey_levels[0]["transition_rules"])
+
+                for i in range(0, len(new_journey_levels)):
+                    jls = new_journey_levels[i]
+                    jls["transition_rules"].extend(
+                        [
+                            {"mode": "e", "next_journey_level": i+1},
+                            {"mode": "w", "next_journey_level": i+1},
+                            {
+                                "mode": "a",
+                                "next_journey_level": i+1,
+                            },
+                        ]
+                    )
+                # level 0: only allow walk access and walk auxilary
+                # must use the trasit modes to get onto the next level, 
+                transition_rules_walk = copy.deepcopy(journey_levels[0]["transition_rules"])
+                transition_rules_walk.extend(
+                    [
+                        {
+                            "mode": "e",
+                            "next_journey_level": 0,
+                        },
+                        {
+                            "mode": "w",
+                            "next_journey_level": 0,
+                        },
+                        {"mode": "a", "next_journey_level": 0},
+                    ]
+                )
                 new_journey_levels.insert(
                     0,
                     {
                         "description": "base",
-                        "destinations_reachable": True,
-                        "transition_rules": transition_rules,
+                        "destinations_reachable": False,
+                        "transition_rules": transition_rules_walk,
                         "waiting_time": None,
                         "boarding_time": None,
                         "boarding_cost": None,


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it? 
The current transit assignment procedures allow movements to walk all the way from origin to destination. On the one hand, this is desirable, as walking all the way is often the lowest "cost" path. Forcing paths that include transit may result in unrealistic paths that will be hard for the mode choice model to completely eliminate. On the other hand, the point of the transit path builder is to create transit paths, not walks paths. An assignment of the on-board survey revealed that about 20 percent of the observed transit movements were given a walk-all-the-way path in the version 2.2.2 (version 1) configuration. We therefore want to test the impact of forcing a transit boarding in the path builder configuration.

## What is the testing plan?
As part of the on-board assignment path builder calibration (see #142), we will document the impact of this on the outcomes. Software changes are minimal and difficult to test outside empirical validation. 


## Code formatting
*Code should be PEP8 compliant before merging by running a package like [`black`](https://pypi.org/project/black/)*

 - [ ] Code linted





