### PR TITLE
Calculate highway reliability in warmstart and 1st global iteration only

### DIFF
--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -109,13 +109,15 @@ class CreateTODScenarios(Component):
         emmebank.extra_function_parameters.el2 = "@capacity"
         emmebank.extra_function_parameters.el3 = "@ja"
         emmebank.extra_function_parameters.el4 = "@static_rel"
+        # get() and put() did not work for los reliability
+        # remove them from the reliability tmplt
         reliability_tmplt = (
             "* (1 + el4 + "
-            "( {factor[LOS_C]} * ( put(get(1).min.1.5) - {threshold[LOS_C]} + 0.01 ) ) * (get(1) .gt. {threshold[LOS_C]})"
-            "+ ( {factor[LOS_D]} * ( get(2) - {threshold[LOS_D]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_D]})"
-            "+ ( {factor[LOS_E]} * ( get(2) - {threshold[LOS_E]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_E]})"
-            "+ ( {factor[LOS_FL]} * ( get(2) - {threshold[LOS_FL]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FL]})"
-            "+ ( {factor[LOS_FH]} * ( get(2) - {threshold[LOS_FH]} + 0.01 )  ) * (get(1) .gt. {threshold[LOS_FH]})"
+            "( {factor[LOS_C]} * ( ((volau + volad)/el2).min.1.5 - {threshold[LOS_C]} + 0.01 ) ) * (((volau + volad)/el2) .gt. {threshold[LOS_C]})"
+            "+ ( {factor[LOS_D]} * ( ((volau + volad)/el2).min.1.5 - {threshold[LOS_D]} + 0.01 )  ) * (((volau + volad)/el2) .gt. {threshold[LOS_D]})"
+            "+ ( {factor[LOS_E]} * ( ((volau + volad)/el2).min.1.5 - {threshold[LOS_E]} + 0.01 )  ) * (((volau + volad)/el2) .gt. {threshold[LOS_E]})"
+            "+ ( {factor[LOS_FL]} * ( ((volau + volad)/el2).min.1.5 - {threshold[LOS_FL]} + 0.01 )  ) * (((volau + volad)/el2) .gt. {threshold[LOS_FL]})"
+            "+ ( {factor[LOS_FH]} * ( ((volau + volad)/el2).min.1.5 - {threshold[LOS_FH]} + 0.01 )  ) * (((volau + volad)/el2) .gt. {threshold[LOS_FH]})"
             ")"
         )
         parameters = {

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -171,7 +171,7 @@ class CreateTODScenarios(Component):
             "(el1 + 60 * (0.25 * (put((volau + volad)/el2) - 1 + "
             "((get(1) - 1) ** 2 + el3 * get(1)) ** 0.5)))"
         )
-        
+
         for f_id in ["fd1", "fd2"]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -152,17 +152,24 @@ class CreateTODScenarios(Component):
                 },
             },
         }
-        # TODO: should have just 3 functions, and map the FT to the vdf
-        # TODO: could optimize expression (to review)
-        bpr_tmplt = "el1 * (1 + 0.20 * ((volau + volad)/el2/0.75)^6)"
-        # "el1 * (1 + 0.20 * put(put((volau + volad)/el2/0.75))*get(1))*get(2)*get(2)"
+        # rewrite bpr_tmplt to use put() and get() for nested functions
+        # keeping the original for reference
+        # bpr_tmplt = "el1 * (1 + 0.20 * ((volau + volad)/el2/0.75)^6)"
+        bpr_tmplt = "el1 * (1 + 0.20 * (put((volau + volad)/el2)/0.75) ** 6)"
+
         fixed_tmplt = "el1"
+
+        # rewrite akcelik_tmplt to use put() and get() for nested functions
+        # keeping the original for reference
+        # akcelik_tmplt = (
+        #     "(el1 + 60 * (0.25 *((volau + volad)/el2 - 1 + "
+        #     "(((volau + volad)/el2 - 1)^2 + el3 * (volau + volad)/el2)^0.5)))"
+        # )
         akcelik_tmplt = (
-            "(el1 + 60 * (0.25 *((volau + volad)/el2 - 1 + "
-            "(((volau + volad)/el2 - 1)^2 + el3 * (volau + volad)/el2)^0.5)))"
-            # "(el1 + 60 * (0.25 *(put(put((volau + volad)/el2) - 1) + "
-            # "(((get(2)*get(2) + (16 * el3 * get(1)^0.5))))"
+            "(el1 + 60 * (0.25 * (put((volau + volad)/el2) - 1 + "
+            "((get(1) - 1) ** 2 + el3 * get(1)) ** 0.5)))"
         )
+        
         for f_id in ["fd1", "fd2"]:
             if emmebank.function(f_id):
                 emmebank.delete_function(f_id)

--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -148,7 +148,9 @@ class HighwayAssignment(Component):
                 iteration = self.controller.iteration
                 warmstart = self.controller.config.warmstart.warmstart
                 assign_classes = [
-                    AssignmentClass(c, time, iteration, calculate_reliability, warmstart)
+                    AssignmentClass(
+                        c, time, iteration, calculate_reliability, warmstart
+                    )
                     for c in self.config.classes
                 ]
                 if iteration > 0:
@@ -163,7 +165,7 @@ class HighwayAssignment(Component):
                     assign_spec = self._get_assignment_spec(
                         assign_classes, path_analysis=False
                     )
-                
+
                     with self.logger.log_start_end(
                         "Run SOLA assignment without path analyses", level="INFO"
                     ):
@@ -177,7 +179,9 @@ class HighwayAssignment(Component):
 
                     exf_pars = scenario.emmebank.extra_function_parameters
                     vdfs = [
-                        f for f in scenario.emmebank.functions() if f.type == "VOLUME_DELAY"
+                        f
+                        for f in scenario.emmebank.functions()
+                        if f.type == "VOLUME_DELAY"
                     ]
                     for function in vdfs:
                         expression = function.expression
@@ -198,7 +202,9 @@ class HighwayAssignment(Component):
                                 "(@static_rel+" + reliability_expr,
                                 {"link": "vdf=%s" % function.id[2:]},
                             )
-                            net_calc("@reliability_sq", "@reliability**2", {"link": "all"})
+                            net_calc(
+                                "@reliability_sq", "@reliability**2", {"link": "all"}
+                            )
 
                 assign_spec = self._get_assignment_spec(
                     assign_classes, path_analysis=True

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -87,7 +87,7 @@ class WarmStartConfig(ConfigItem):
     Note that the components will be executed in the order listed.
 
     Properties:
-        warmstart: Boolean indicating whether warmstart demand matrices are used. 
+        warmstart: Boolean indicating whether warmstart demand matrices are used.
             If set to True, the global iteration 0 will either assign warmstart demand for highway and transit, or skip the assignment and just use warmstart skims.
             If set to False, the global iteration 0 will assign zero demand for highway and transit.
         warmstart_skim: Boolean indicating whether to use warmstart skims. If set to True, then skips warmstart assignment in iteraton 0.
@@ -952,10 +952,10 @@ class HighwayConfig(ConfigItem):
             to the free-flow speed, capacity, and critical speed values
         interchange_nodes_file: relative path to the interchange nodes file, this is
             used for calculating highway reliability
-        reliability: bool to skim highway reliability. Default to true. If true, assignment 
-            will be run twice in global iterations 0 (warmstart) and 1, to calculate reliability, 
-            assignment will be run only once in global iterations 2 and 3, 
-            reliability skim will stay the same as global iteration 1. 
+        reliability: bool to skim highway reliability. Default to true. If true, assignment
+            will be run twice in global iterations 0 (warmstart) and 1, to calculate reliability,
+            assignment will be run only once in global iterations 2 and 3,
+            reliability skim will stay the same as global iteration 1.
             If false, reliability will not be calculated nor skimmed in all global
             iterations, and the resulting reliability skims will be 0.
     """

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -952,6 +952,12 @@ class HighwayConfig(ConfigItem):
             to the free-flow speed, capacity, and critical speed values
         interchange_nodes_file: relative path to the interchange nodes file, this is
             used for calculating highway reliability
+        reliability: bool to skim highway reliability. Default to true. If true, assignment 
+            will be run twice in global iterations 0 (warmstart) and 1, to calculate reliability, 
+            assignment will be run only once in global iterations 2 and 3, 
+            reliability skim will stay the same as global iteration 1. 
+            If false, reliability will not be calculated nor skimmed in all global
+            iterations, and the resulting reliability skims will be 0.
     """
 
     generic_highway_mode_code: str = Field(min_length=1, max_length=1)
@@ -967,6 +973,7 @@ class HighwayConfig(ConfigItem):
     classes: Tuple[HighwayClassConfig, ...] = Field()
     capclass_lookup: Tuple[HighwayCapClassConfig, ...] = Field()
     interchange_nodes_file: str = Field()
+    reliability: bool = Field(default=True)
 
     @validator("output_skim_filename_tmpl")
     def valid_skim_template(value):


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?
This PR address #146 

The updated reliability design:

- [x] Reliability continues to be included in the VDFs. It has two parts: a static part and a LOS-based part. This is same as before.
- [x] When running reliability, it continues to require two assignments. After the first assignment, reliability is written out as a link attribute, and gets skimmed in the second assignment. This is same as before.
- [x] Implement a switch in the model config for reliability, so that users can choose to turn it on or off.
- [x] If turned on, reliability is run in global iteration 0 (warmstart assignment) and 1 only. Assignment is run twice for glob iter 0 and 1, reliability is calculated and updated as a link-level attribute, and reliability skim is saved in the emmbank. Assignment is run only once for glob iter 2 and 3, the reliability skim does not get updated.
- [x] If turned off, assignment is run once in all glob iter. Reliability is included in the VDFs, but not saved out as a link attribute, reliability skim will be skipped and be written out as 0.

## What is the testing plan?
Should test run global iteration 1 and 2's highway assignment to make sure in global iter 1, assignment is run twice and highway reliability is calculated; and in glob iter 2, assignment is run once and highway reliability is not updated.

*Demonstrate the code is solid by discussing how results are verified and covered by tests*

 - [x] When reliability = true, check glob iter 1 calculated reliability, and glob iter 2 does not. Check the reliability skims from glob iter 1 and 2, to confirm they are the same.
 - [x] When reliability = false, check assignment is run once in both glob iter 1 and 2, and the reliability skims are all 0.


## Questions

- [x] When reliability = false, do we still want to keep the same VDF (with reliability in it)? If yes, then the travel time includes reliability, and the reliability in travel time is not consistent with the reliability skims.

## Code formatting
*Code should be PEP8 compliant before merging by running a package like [`black`](https://pypi.org/project/black/)*

 - [x] Code linted

## Applicable Issues
*Please do not create a Pull Request without creating an issue first.*

#### Issues List

 -  closes #146 


