### PR TITLE
Move Sampling Rate to Config

### DIFF
--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -61,9 +61,9 @@ class HouseholdModel(Component):
         run_process(commands, name="start_matrix_manager")
 
     def _run_resident_model(self):
-        sample_rate_iteration = {1: 0.05, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
+        sample_rate_iteration = self.config.sample_rate_by_iteration
         iteration = self.controller.iteration
-        sample_rate = sample_rate_iteration[iteration]
+        sample_rate = sample_rate_iteration[iteration - 1]
         _shutil.copyfile("CTRAMP\\runtime\\mtctm2.properties", "mtctm2.properties")
         commands = [
             f"cd /d {self.controller.run_dir}",

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -336,6 +336,7 @@ class HouseholdConfig(ConfigItem):
     ctramp_mode_names: Dict[float, str]
     income_segment: Dict[str, Union[float, str, list]]
     ctramp_hh_file: str
+    sample_rate_by_iteration: List[float]
 
 
 @dataclass(frozen=True)
@@ -1508,6 +1509,15 @@ class Configuration(ConfigItem):
                 values["run"]["end_iteration"]
             ), f"'transit.stop_criteria must be the same or greater length as end_iteration,\
                 that includes global iteration 1 to {values['run']['end_iteration']}'"
+        return value
+
+    @validator("household", always=True)
+    def sample_rate_length(cls, value, values):
+        """Validate highway.sample_rate_by_iteration is a list of length greater or equal to global iterations."""
+        if "run" in values:
+            assert len(value.sample_rate_by_iteration) >= (
+                values["run"]["end_iteration"]
+            ), f"'highway.sample_rate_by_iteration must be the same or greater length as end_iteration'"
         return value
 
 


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?
The sampling rate for the resident passenger component are currently hardcoded in the code. This PR brings the rates into model_config file. 

## Applicable Issues
*Please do not create a Pull Request without creating an issue first.*

#### Issues List
 -  closes #170 


