### PR TITLE
Update Truck Model to use correct landuse input

### DIFF
--- a/tm2py/components/demand/commercial.py
+++ b/tm2py/components/demand/commercial.py
@@ -257,13 +257,13 @@ class CommercialVehicleTripGeneration(Subcomponent):
         TOTHH, total households
         """
         maz_data_file = self.get_abs_path(
-            self.controller.config.scenario.maz_landuse_file
+            self.controller.config.scenario.landuse_file
         )
         maz_input_data = pd.read_csv(maz_data_file)
         zones = self.component.emme_scenario.zone_numbers
-        maz_input_data = maz_input_data[maz_input_data["TAZ_ORIGINAL"].isin(zones)]
-        taz_input_data = maz_input_data.groupby(["TAZ_ORIGINAL"]).sum()
-        taz_input_data = taz_input_data.sort_values(by="TAZ_ORIGINAL")
+        maz_input_data = maz_input_data[maz_input_data["TAZ"].isin(zones)]
+        taz_input_data = maz_input_data.groupby(["TAZ"]).sum()
+        taz_input_data = taz_input_data.sort_values(by="TAZ")
         # combine categories
         taz_landuse = pd.DataFrame()
         for total_column, sub_categories in _land_use_aggregation.items():

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -573,7 +573,7 @@ class CreateTODScenarios(Component):
         # the average density including all MAZs within the specified buffer distance
         buff_dist = 5280 * self.controller.config.highway.area_type_buffer_dist_miles
         maz_data_file_path = self.get_abs_path(
-            self.controller.config.scenario.maz_landuse_file
+            self.controller.config.scenario.landuse_file
         )
         maz_landuse_data: Dict[
             int, Dict[Any, Union[str, int, Tuple[float, float]]]

--- a/tm2py/components/network/highway/drive_access_skims.py
+++ b/tm2py/components/network/highway/drive_access_skims.py
@@ -95,7 +95,7 @@ class DriveAccessSkims(Component):
     def _maz_taz_correspondence(self) -> pd.DataFrame:
         """Load maz data (landuse file) which has the MAZ-> TAZ correspondence"""
         maz_data_file = self.get_abs_path(
-            self.controller.config.scenario.maz_landuse_file
+            self.controller.config.scenario.landuse_file
         )
         maz_input_data = pd.read_csv(maz_data_file)
         # drop the other landuse columns

--- a/tm2py/components/network/highway/highway_maz.py
+++ b/tm2py/components/network/highway/highway_maz.py
@@ -223,7 +223,7 @@ class AssignMAZSPDemand(Component):
         )
         network = self._network
         # maz data
-        # maz_file = self.get_abs_path(self.controller.config.scenario.maz_landuse_file)
+        # maz_file = self.get_abs_path(self.controller.config.scenario.landuse_file)
         # maz_df = pd.read_csv(maz_file)
         # maz_county_dict = dict(zip(maz_df["MAZ_ORIGINAL"], maz_df["CountyName"]))
         # NOTE: every maz must have a valid #node_county

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -45,14 +45,11 @@ class ScenarioConfig(ConfigItem):
         verify: optional, default False if specified as True components will run
             additional post-process verify step to validate results / outputs
             (not implemented yet)
-        maz_landuse_file: relative path to maz_landuse_file used by multiple
-            components
         name: scenario name string
         year: model year, must be at least 2005
         landuse_file: TAZ file
     """
 
-    maz_landuse_file: pathlib.Path
     zone_seq_file: pathlib.Path
     landuse_file: pathlib.Path
     landuse_index_column: str


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?
This PR fixed #204 by aligning the truck model with the correct land use input and removing a confusing, outdated file.

**Changes:**

1. Use landuse input file `maz_data_withDensity.csv` saved in parameter `landuse_file` in truck model
2. Remove parameter `maz_landuse_file`

## What is the testing plan?
Reran 1 iteration of the model, confirmed the truck mode now generates truck trips for the entire model region. Verified that removing `maz_data.csv` does not break other models or components.

## Code formatting

*Code should be PEP8 compliant before merging by running a package like [`black`](https://pypi.org/project/black/)*

- [ ] Code linted

## Applicable Issues

*Please do not create a Pull Request without creating an issue first.*

*Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.*

- closes https://github.com/BayAreaMetro/tm2py/issues/204
